### PR TITLE
aiohttp connection pooling

### DIFF
--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -324,11 +324,11 @@ async def handle_subscription(request: Request) -> JSONResponse:
             async with conn.cursor() as cur:
                 run_query = False
                 if len(query_parts) > 0:
-                    where_clause = " OR ".join(query_parts)
+                    where_clause = " AND ".join(query_parts)
                     run_query = True
                 if len(tag_values) > 0:
                     tag_clause = await generate_query(tag_values)
-                    where_clause = str(where_clause) + " OR " + str(tag_clause)
+                    where_clause = str(where_clause) + " AND " + str(tag_clause)
                     run_query = True
                 sql_query = f"SELECT * FROM events WHERE {where_clause};"
                 logger.debug(f"SQL query constructed: {sql_query}")

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -192,14 +192,7 @@ class ExtractedResponse:
             Union[Tuple[str, Optional[str], str, Optional[str]], List[Tuple[str, Optional[str], Dict[str, Any]]], Tuple[str, Optional[str]]]: The formatted response.
 
         """
-        if self.event_type == "OK":
-            client_response: Tuple[str, Optional[str], str, Optional[str]] = (
-                self.event_type,
-                self.subscription_id,
-                self.results,
-                self.comment,
-            )
-        elif self.event_type == "EVENT":
+        if self.event_type == "EVENT":
             events_to_send = []
             tasks = []
             for event_result in self.results:
@@ -208,6 +201,14 @@ class ExtractedResponse:
             await asyncio.gather(*tasks)
 
             return events_to_send
+        elif self.event_type == "OK":
+            client_response: Tuple[str, Optional[str], str, Optional[str]] = (
+                self.event_type,
+                self.subscription_id,
+                self.results,
+                self.comment,
+            )
+
         else:
             # Return EOSE
             client_response: Tuple[str, Optional[str]] = (
@@ -273,15 +274,17 @@ class WebsocketMessages:
 unique_sessions = []
 client_ips = []
 
+
 class WebSocketHandler:
     def __init__(self):
         self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
 
-    async def handle_websocket_connection(self,
+    async def handle_websocket_connection(
+        self,
         websocket: websockets.WebSocketServerProtocol,
     ) -> None:
         global unique_sessions, client_ips
-    
+
         async with self.session as session:
             try:
                 async for message in websocket:
@@ -298,7 +301,7 @@ class WebSocketHandler:
                             ],
                         )
                         logger.debug(f"WS event payload is {ws_message.event_payload}")
-    
+
                         if not await rate_limiter.check_request(
                             ws_message.obfuscated_client_ip
                         ):
@@ -323,7 +326,7 @@ class WebSocketHandler:
                             await websocket.send(json.dumps(rate_limit_response))
                             await websocket.close()
                             return
-    
+
                         if ws_message.event_type == "EVENT":
                             logger.debug(
                                 f"Event to be sent payload is: {ws_message.event_payload} of type {type(ws_message.event_payload)}"
@@ -350,16 +353,16 @@ class WebSocketHandler:
                                 f"closing {ws_message.subscription_id}",
                             )
                             await websocket.send(json.dumps(response))
-    
+
                     except Exception as exc:
                         logger.error(f"Inner loop {exc}")
-    
+
             except aiohttp.ClientError as e:
                 logger.error(f"http client error {e}")
-    
+
             except Exception as e:
                 logger.error(f"Error occurred while starting the server: {e}")
-    
+
 
 async def send_event_to_handler(
     session: aiohttp.ClientSession,
@@ -433,7 +436,9 @@ async def send_subscription_to_handler(
 if __name__ == "__main__":
     rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=30000)
     handler = WebSocketHandler()
-    start_server = websockets.serve(handler.handle_websocket_connection, "0.0.0.0", 8008)
+    start_server = websockets.serve(
+        handler.handle_websocket_connection, "0.0.0.0", 8008
+    )
 
     try:
         asyncio.get_event_loop().run_until_complete(start_server)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -273,90 +273,93 @@ class WebsocketMessages:
 unique_sessions = []
 client_ips = []
 
+class WebSocketHandler:
+    def __init__(self):
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
 
-async def handle_websocket_connection(
-    websocket: websockets.WebSocketServerProtocol,
-) -> None:
-    global unique_sessions, client_ips
-
-    async with aiohttp.ClientSession() as session:
-        try:
-            async for message in websocket:
-                try:
-                    ws_message = WebsocketMessages(
-                        message=json.loads(message), websocket=websocket
-                    )
-                    logger.debug(f"UUID = {ws_message.uuid}")
-                    statsd.increment(
-                        "nostr.new_connection.count",
-                        tags=[
-                            f"client_ip:{ws_message.obfuscated_client_ip}",
-                            f"nostr_client:{ws_message.origin}",
-                        ],
-                    )
-                    logger.debug(f"WS event payload is {ws_message.event_payload}")
-
-                    if not await rate_limiter.check_request(
-                        ws_message.obfuscated_client_ip
-                    ):
-                        logger.warning(
-                            f"Rate limit exceeded for client: {ws_message.obfuscated_client_ip}"
+    async def handle_websocket_connection(self,
+        websocket: websockets.WebSocketServerProtocol,
+    ) -> None:
+        global unique_sessions, client_ips
+    
+        async with self.session as session:
+            try:
+                async for message in websocket:
+                    try:
+                        ws_message = WebsocketMessages(
+                            message=json.loads(message), websocket=websocket
                         )
-                        rate_limit_response: Tuple[
-                            str, Optional[str], str, Optional[str]
-                        ] = (
-                            "OK",
-                            "nostafarian419",
-                            "false",
-                            "rate-limited: slow your roll nostrich",
-                        )
+                        logger.debug(f"UUID = {ws_message.uuid}")
                         statsd.increment(
-                            "nostr.client.rate_limited.count",
+                            "nostr.new_connection.count",
                             tags=[
                                 f"client_ip:{ws_message.obfuscated_client_ip}",
                                 f"nostr_client:{ws_message.origin}",
                             ],
                         )
-                        await websocket.send(json.dumps(rate_limit_response))
-                        await websocket.close()
-                        return
-
-                    if ws_message.event_type == "EVENT":
-                        logger.debug(
-                            f"Event to be sent payload is: {ws_message.event_payload} of type {type(ws_message.event_payload)}"
-                        )
-                        await send_event_to_handler(
-                            session=session,
-                            event_dict=dict(ws_message.event_payload),
-                            websocket=websocket,
-                        )
-                    elif ws_message.event_type == "REQ":
-                        logger.debug(f"Entering REQ branch")
-                        logger.debug(
-                            f"Payload is {ws_message.event_payload} and of type: {type(ws_message.event_payload)}"
-                        )
-                        await send_subscription_to_handler(
-                            session=session,
-                            event_dict=ws_message.event_payload,
-                            subscription_id=ws_message.subscription_id,
-                            websocket=websocket,
-                        )
-                    elif ws_message.event_type == "CLOSE":
-                        response: Tuple[str, str] = (
-                            "NOTICE",
-                            f"closing {ws_message.subscription_id}",
-                        )
-                        await websocket.send(json.dumps(response))
-
-                except Exception as exc:
-                    logger.error(f"Inner loop {exc}")
-
-        except aiohttp.ClientError as e:
-            logger.error(f"http client error {e}")
-
-        except Exception as e:
-            logger.error(f"Error occurred while starting the server: {e}")
-
+                        logger.debug(f"WS event payload is {ws_message.event_payload}")
+    
+                        if not await rate_limiter.check_request(
+                            ws_message.obfuscated_client_ip
+                        ):
+                            logger.warning(
+                                f"Rate limit exceeded for client: {ws_message.obfuscated_client_ip}"
+                            )
+                            rate_limit_response: Tuple[
+                                str, Optional[str], str, Optional[str]
+                            ] = (
+                                "OK",
+                                "nostafarian419",
+                                "false",
+                                "rate-limited: slow your roll nostrich",
+                            )
+                            statsd.increment(
+                                "nostr.client.rate_limited.count",
+                                tags=[
+                                    f"client_ip:{ws_message.obfuscated_client_ip}",
+                                    f"nostr_client:{ws_message.origin}",
+                                ],
+                            )
+                            await websocket.send(json.dumps(rate_limit_response))
+                            await websocket.close()
+                            return
+    
+                        if ws_message.event_type == "EVENT":
+                            logger.debug(
+                                f"Event to be sent payload is: {ws_message.event_payload} of type {type(ws_message.event_payload)}"
+                            )
+                            await send_event_to_handler(
+                                session=session,
+                                event_dict=dict(ws_message.event_payload),
+                                websocket=websocket,
+                            )
+                        elif ws_message.event_type == "REQ":
+                            logger.debug(f"Entering REQ branch")
+                            logger.debug(
+                                f"Payload is {ws_message.event_payload} and of type: {type(ws_message.event_payload)}"
+                            )
+                            await send_subscription_to_handler(
+                                session=session,
+                                event_dict=ws_message.event_payload,
+                                subscription_id=ws_message.subscription_id,
+                                websocket=websocket,
+                            )
+                        elif ws_message.event_type == "CLOSE":
+                            response: Tuple[str, str] = (
+                                "NOTICE",
+                                f"closing {ws_message.subscription_id}",
+                            )
+                            await websocket.send(json.dumps(response))
+    
+                    except Exception as exc:
+                        logger.error(f"Inner loop {exc}")
+    
+            except aiohttp.ClientError as e:
+                logger.error(f"http client error {e}")
+    
+            except Exception as e:
+                logger.error(f"Error occurred while starting the server: {e}")
+    
 
 async def send_event_to_handler(
     session: aiohttp.ClientSession,
@@ -429,11 +432,13 @@ async def send_subscription_to_handler(
 
 if __name__ == "__main__":
     rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=30000)
+    handler = WebSocketHandler()
+    start_server = websockets.serve(handler.handle_websocket_connection, "0.0.0.0", 8008)
 
     try:
-        start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)
         asyncio.get_event_loop().run_until_complete(start_server)
         asyncio.get_event_loop().run_forever()
-
-    except Exception as e:
-        logger.error(f"Error occurred while starting the server main loop: {e}")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        handler.session.close()


### PR DESCRIPTION
* Changed query constructor to use `AND` when adding query clauses, Array searches within `id`, `pubkey`, `kinds` and `tags` still use `OR` 
  * No longer returning unnecessary rows and bogging down services
  * Resolves #33 
* Created `WebSocketHandler` class to define a single `aiohttp.ClientSession` object and pool http connections
* Switched order of branches of `format_response()` to make `EVENT` type first branch