### PR TITLE
Re-add Redis cache

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+## v0.7
+**Enhancements**
+* Re-added redis cache to serve frequent queries faster
+* Added event classes to `event_handler` service for readability and portability
+* More efficent use of coroutines
+  * Use `asyncio.gather` to prepare and send responses to websocket client
+  * Converted async methods to sync methods where appropriate to reduce overhead
+* Added auto-multiline log detection for Datadog agent to more easily read stack traces
+* Cleaned up noisy `DEBUG` log lines
+* Better error handling for empty responses
+
+**Bug Fixes**
+* Fixed `websocket_handler` JSON loads error that occured when loading empty payloads to no longer restart the websocket server
+  * Server continues and maintains the websocket connection
+
 ## v0.6
 **Enhancements**
 * Obfuscate `client_ip` tag by using a hashed value for their ip address

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 **Enhancements**
 * Re-added redis cache to serve frequent queries faster
 * Added event classes to `event_handler` service for readability and portability
-* More efficent use of coroutines
+* More efficient  use of coroutines
   * Use `asyncio.gather` to prepare and send responses to websocket client
   * Converted async methods to sync methods where appropriate to reduce overhead
 * Added auto-multiline log detection for Datadog agent to more easily read stack traces
@@ -10,7 +10,7 @@
 * Better error handling for empty responses
 
 **Bug Fixes**
-* Fixed `websocket_handler` JSON loads error that occured when loading empty payloads to no longer restart the websocket server
+* Fixed `websocket_handler` JSON loads error that occurred when loading empty payloads to no longer restart the websocket server
   * Server continues and maintains the websocket connection
 
 ## v0.6

--- a/docker_stuff/Dockerfile.event_handler
+++ b/docker_stuff/Dockerfile.event_handler
@@ -7,6 +7,7 @@ COPY .env .
 
 RUN pip install --no-cache-dir -r eh_requirements.txt
 COPY ./python_stuff/event_handler.py .
+COPY ./python_stuff/event_classes.py .
 
 
 CMD ["ddtrace-run", "python", "event_handler.py"]

--- a/docker_stuff/docker-compose.yaml
+++ b/docker_stuff/docker-compose.yaml
@@ -106,6 +106,7 @@ services:
       - DD_CONTAINER_EXCLUDE="image:datadog/agent:latest"
       - DD_LOG_LEVEL=info
       - DD_REMOTE_CONFIGURATION_ENABLED=true
+      - DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -128,7 +128,9 @@ class Subscription:
         return complete_query
 
     async def sanitize_event_keys(self, filters, logger) -> Dict:
+        updated_keys = {}
         try:
+            
             try:
                 # limit_var = filters.get("limit")
                 filters.pop("limit")
@@ -142,7 +144,7 @@ class Subscription:
                 "kinds": "kind",
                 "ids": "id",
             }
-            updated_keys = {}
+            
             if len(filters) > 0:
                 for key in filters:
                     new_key = key_mappings.get(key, key)

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -120,9 +120,11 @@ class Subscription:
                 array_search = f"{item} = ANY(ARRAY {updated_keys[item]})"
                 query_parts.append(array_search)
 
+            logger.debug(f"Returning parse san key {tag_values} and qp: {query_parts}")
+
             return tag_values, query_parts
         except Exception as exc:
-            logger.warning(f"query not sanitized (maybe empty value)")
+            logger.warning(f"query not sanitized (maybe empty value), error is: {exc}")
             return {}, {}
 
     async def generate_query(self, tags) -> str:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -159,7 +159,7 @@ class Subscription:
             return None
 
     async def parse_filters(self, filters: dict, logger) -> tuple:
-        updated_keys = await self.sanitize_event_keys(filters)
+        updated_keys = await self.sanitize_event_keys(filters, logger)
         if updated_keys:
             tag_values, query_parts = await self.parse_sanitized_keys(updated_keys, logger)
         return tag_values, query_parts

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -57,11 +57,12 @@ class Subscription:
     async def sanitize_event_keys(self, filters, logger) -> Dict:
         try:
             try:
-                limit_var = filters.get("limit")
+                #limit_var = filters.get("limit")
                 filters.pop("limit")
             except:
                 logger.debug(f"No limit")
             #filters["limit"] = min(200, limit_var)
+            logger.debug(f"Filters are: {filters}")
 
             key_mappings = {
                 "authors": "pubkey",
@@ -160,6 +161,7 @@ class Subscription:
 
     async def parse_filters(self, filters: dict, logger) -> tuple:
         updated_keys = await self.sanitize_event_keys(filters, logger)
+        logger.debug(f"Updated keys is: {updated_keys}")
         if updated_keys:
             tag_values, query_parts = await self.parse_sanitized_keys(updated_keys, logger)
         return tag_values, query_parts

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -134,11 +134,8 @@ class Subscription:
             try:
                 limit = filters.get("limit", 100)
                 filters.pop("limit")
-                # filters["limit"]
             except:
                 logger.debug(f"No limit")
-            # filters["limit"] = min(200, limit_var)
-            logger.debug(f"Filters are: {filters}")
 
             key_mappings = {
                 "authors": "pubkey",
@@ -163,7 +160,6 @@ class Subscription:
     async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
         query_parts = []
         tag_values = []
-        logger.debug(f"parse san keys rec updatred keys = {updated_keys}")
 
         try:
             for item in updated_keys:
@@ -197,7 +193,6 @@ class Subscription:
                 array_search = f"{item} = ANY(ARRAY {updated_keys[item]})"
                 query_parts.append(array_search)
 
-            logger.debug(f"Returning parse san key {tag_values} and qp: {query_parts}")
             return tag_values, query_parts
         except Exception as exc:
             logger.warning(
@@ -245,7 +240,6 @@ class Subscription:
 
     def base_query_builder(self, tag_values, query_parts, limit, logger):
         try:
-            logger.debug(f"Base q builder, tg is {tag_values}, qp is {query_parts}")
             if query_parts:
                 self.where_clause = " AND ".join(query_parts)
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -1,0 +1,165 @@
+import asyncio
+import json
+from typing import List, Tuple, Dict
+
+
+class Event:
+    def __init__(
+        self,
+        event_id: str,
+        pubkey: str,
+        kind: int,
+        created_at: int,
+        tags: List,
+        content: str,
+        sig: str,
+    ) -> None:
+        self.event_id = event_id
+        self.pubkey = pubkey
+        self.kind = kind
+        self.created_at = created_at
+        self.tags = tags
+        self.content = content
+        self.sig = sig
+
+    def __str__(self) -> str:
+        return f"{self.event_id}, {self.pubkey}, {self.kind}, {self.created_at}, {self.tags}, {self.content}, {self.sig} "
+
+
+class Subscription:
+    def __init__(self, request_payload: dict) -> None:
+        self.filters = request_payload.get("event_dict", {})
+        self.subscription_id = request_payload.get("subscription_id")
+        self.where_clause = None
+        self.base_query = f"SELECT * FROM events WHERE {self.where_clause};"
+        self.column_names = [
+            "id",
+            "pubkey",
+            "kind",
+            "created_at",
+            "tags",
+            "content",
+            "sig",
+        ]
+
+    async def generate_query(self):
+        base_query = f"SELECT * FROM events WHERE {self.where_clause};"
+
+    async def generate_tag_clause(self, tags, logger) -> str:
+        tag_clause = (
+            " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
+        )
+        conditions = [f"elem @> '{json.dumps(tag_pair)}'" for tag_pair in tags]
+
+        complete_query = tag_clause.format(" OR ".join(conditions))
+        return complete_query
+
+    async def sanitize_event_keys(self, filters, logger) -> Dict:
+        try:
+            try:
+                limit_var = filters.get("limit")
+                filters.pop("limit")
+            except:
+                logger.debug(f"No limit")
+            filters["limit"] = min(200, limit_var)
+
+            key_mappings = {
+                "authors": "pubkey",
+                "kinds": "kind",
+                "ids": "id",
+            }
+            updated_keys = {}
+            if len(filters) > 0:
+                for key in filters:
+                    new_key = key_mappings.get(key, key)
+                    if new_key != key:
+                        stored_val = filters[key]
+                        updated_keys[new_key] = stored_val
+                    else:
+                        updated_keys[key] = filters[key]
+
+            return updated_keys
+        except Exception as e:
+            logger.error(f"An unexpected error occurred: {e}")
+            return updated_keys
+
+    async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
+        query_parts = []
+
+        try:
+            for item in updated_keys:
+                outer_break = False
+
+                if item.startswith("#"):
+                    try:
+                        tag_values = [
+                            json.dumps([item[1], tags]) for tags in updated_keys[item]
+                        ]
+
+                        outer_break = True
+                        continue
+                    except TypeError as e:
+                        logger.error(f"Error processing tags for key {item}: {e}")
+
+                elif item in ["since", "until"]:
+                    if item == "since":
+                        since = f'created_at > {updated_keys["since"]}'
+                        query_parts.append(since)
+                        outer_break = True
+                        continue
+                    elif item == "until":
+                        until = f'created_at < {updated_keys["until"]}'
+                        query_parts.append(until)
+                        outer_break = True
+                        continue
+
+                if outer_break:
+                    continue
+
+                array_search = f"{item} = ANY(ARRAY {updated_keys[item]})"
+                query_parts.append(array_search)
+
+            return tag_values, query_parts
+        except Exception as exc:
+            logger.warning(f"query not sanitized (maybe empty value)")
+            return {}, {}
+
+    async def generate_query(self, tags, logger) -> str:
+        base_query = (
+            "EXISTS (SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
+        )
+        or_conditions = " OR ".join(f"elem @> '{tag}'" for tag in tags)
+        complete_query = base_query.format(or_conditions)
+        return complete_query
+
+    async def _parser_worker(self, record, column_added) -> None:
+        row_result = {}
+        i = 0
+        for item in record:
+            row_result[self.column_names[i]] = item
+            i += 1
+        column_added.append([row_result])
+
+    async def query_result_parser(self, query_result) -> List:
+        column_added = []
+        try:
+            tasks = [
+                self._parser_worker(record, column_added) for record in query_result
+            ]
+            await asyncio.gather(*tasks)
+            return column_added
+        except:
+            return None
+
+    async def fetch_data_from_cache(self, redis_key, redis_client) -> bytes:
+        cached_data = redis_client.get(redis_key)
+        if cached_data:
+            return cached_data
+        else:
+            return None
+
+    async def parse_filters(self, filters: dict) -> tuple:
+        updated_keys = await self.sanitize_event_keys(filters)
+        if updated_keys:
+            tag_values, query_parts = await self.parse_sanitized_keys(updated_keys)
+        return tag_values, query_parts

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -249,6 +249,7 @@ class Subscription:
         
     async def base_query_builder(self, tag_values, query_parts, logger):
         try:
+            logger.debug(f"Base q builder, tg is {tag_values}, qp is {query_parts}")
             if query_parts:
                 self.where_clause = " AND ".join(query_parts)
     

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -265,7 +265,7 @@ class Subscription:
             if not limit:
                 limit = 100
 
-            self.base_query = f"SELECT * FROM events WHERE {self.where_clause} LIMIT {limit} ORDER BY created_at;"
+            self.base_query = f"SELECT * FROM events WHERE {self.where_clause} ORDER BY created_at LIMIT {limit} ;"
             logger.debug(f"SQL query constructed: {self.base_query}")
             return self.base_query
         except Exception as exc:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -94,7 +94,7 @@ class Subscription:
                 if item.startswith("#"):
                     try:
                         tag_values = [
-                            json.dumps([item[1], tags]) for tags in updated_keys[item]
+                            ([item[1], tags]) for tags in updated_keys[item]
                         ]
 
                         outer_break = True

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -157,7 +157,7 @@ class Subscription:
             return updated_keys
         except Exception as e:
             logger.error(f"An unexpected error occurred: {e}")
-            return updated_keys
+            return None
 
     async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
         query_parts = []
@@ -199,7 +199,7 @@ class Subscription:
             return tag_values, query_parts
         except Exception as exc:
             logger.warning(f"query not sanitized (maybe empty value), error is: {exc}")
-            return [], []
+            return tag_values, query_parts
 
     async def generate_query(self, tags) -> str:
         base_query = (
@@ -242,7 +242,9 @@ class Subscription:
             tag_values, query_parts = await self.parse_sanitized_keys(
                 updated_keys, logger
             )
-        return tag_values, query_parts
+            return tag_values, query_parts
+        else:
+            return None, {}
 
     async def sub_response_builder(
         self, event_type, subscription_id, results_json, http_status_code

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -106,8 +106,8 @@ class Subscription:
     def __init__(self, request_payload: dict) -> None:
         self.filters = request_payload.get("event_dict", {})
         self.subscription_id = request_payload.get("subscription_id")
-        self.where_clause = None
-        self.base_query = f"SELECT * FROM events WHERE {self.where_clause} LIMIT 100;"
+        #@self.where_clause = None
+        #@self.base_query = f"SELECT * FROM events WHERE {self.where_clause} LIMIT 100;"
         self.column_names = [
             "id",
             "pubkey",
@@ -256,6 +256,8 @@ class Subscription:
             if tag_values:
                 tag_clause = await self.generate_tag_clause(tag_values)
                 self.where_clause += f" AND {tag_clause}"
+
+            self.base_query = f"SELECT * FROM events WHERE {self.where_clause} LIMIT 100;"
             logger.debug(f"SQL query constructed: {self.base_query}")
             return self.base_query
         except Exception as exc:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from typing import List, Tuple, Dict
+from fastapi.responses import JSONResponse
 
 
 class Event:
@@ -42,8 +43,6 @@ class Subscription:
             "sig",
         ]
 
-    #async def generate_query(self):
-    #    base_query = f"SELECT * FROM events WHERE {self.where_clause};"
 
     async def generate_tag_clause(self, tags) -> str:
         tag_clause = (
@@ -168,3 +167,14 @@ class Subscription:
         if updated_keys:
             tag_values, query_parts = await self.parse_sanitized_keys(updated_keys, logger)
         return tag_values, query_parts
+    
+    def sub_response_builder(self, event_type, subscription_id, results_json, http_status_code):
+        return JSONResponse(
+                content={
+                    "event": event_type,
+                    "subscription_id": subscription_id,
+                    "results_json": results_json,
+                },
+                status_code= http_status_code,
+            )
+

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -5,6 +5,24 @@ from fastapi.responses import JSONResponse
 
 
 class Event:
+    """
+       Represents an event object with attributes such as event ID, public key, kind, created timestamp, tags, content, and signature.
+   
+       Attributes:
+           event_id (str): The ID of the event.
+           pubkey (str): The public key associated with the event.
+           kind (int): The type or kind of the event.
+           created_at (int): The timestamp when the event was created.
+           tags (List): A list of tags associated with the event.
+           content (str): The content of the event.
+           sig (str): The signature of the event.
+   
+       Methods:
+           delete_check: Checks and deletes the event from the database.
+           add_event: Adds the event to the database.
+           evt_response: Builds and returns the JSON response for the event.
+    """
+
     def __init__(
         self,
         event_id: str,
@@ -63,6 +81,28 @@ class Event:
 
 
 class Subscription:
+    """
+    Represents a subscription object with attributes and methods for handling subscription-related operations.
+
+    Attributes:
+        filters (dict): Dictionary containing filters for the subscription.
+        subscription_id (str): The ID of the subscription.
+        where_clause (str): The WHERE clause of the base SQL query.
+        base_query (str): The base SQL query for fetching events.
+        column_names (List): List of column names for event attributes.
+
+    Methods:
+        generate_tag_clause: Generates the tag clause for SQL query based on given tags.
+        sanitize_event_keys: Sanitizes the event keys by mapping and filtering the filters.
+        parse_sanitized_keys: Parses and sanitizes the updated keys to generate tag values and query parts.
+        generate_query: Generates the SQL query based on provided tags.
+        _parser_worker: Worker function to parse and add records to the column.
+        query_result_parser: Parses the query result and adds columns accordingly.
+        fetch_data_from_cache: Fetches data from cache based on the provided Redis key.
+        parse_filters: Parses and sanitizes filters to generate tag values and query parts.
+        sub_response_builder: Builds and returns the JSON response for the subscription.
+    """
+
     def __init__(self, request_payload: dict) -> None:
         self.filters = request_payload.get("event_dict", {})
         self.subscription_id = request_payload.get("subscription_id")

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -134,7 +134,7 @@ class Subscription:
             try:
                 limit = filters.get("limit", 100)
                 filters.pop("limit")
-                #filters["limit"]
+                # filters["limit"]
             except:
                 logger.debug(f"No limit")
             # filters["limit"] = min(200, limit_var)
@@ -154,8 +154,7 @@ class Subscription:
                         updated_keys[new_key] = stored_val
                     else:
                         updated_keys[key] = filters[key]
-            
-            
+
             return updated_keys, limit
         except Exception as e:
             logger.error(f"An unexpected error occurred: {e}", exc_info=True)
@@ -240,7 +239,7 @@ class Subscription:
             tag_values, query_parts = await self.parse_sanitized_keys(
                 updated_keys, logger
             )
-            return tag_values, query_parts , limit
+            return tag_values, query_parts, limit
         else:
             return {}, {}, None
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -86,6 +86,7 @@ class Subscription:
 
     async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
         query_parts = []
+        tag_values = []
 
         try:
             for item in updated_keys:
@@ -93,9 +94,10 @@ class Subscription:
 
                 if item.startswith("#"):
                     try:
-                        tag_values = [
-                            ([item[1], tags]) for tags in updated_keys[item]
-                        ]
+
+                        for tags in updated_keys[item]:
+                            tag_values.append(json.dumps([item[1], tags]))
+
 
                         outer_break = True
                         continue
@@ -121,11 +123,10 @@ class Subscription:
                 query_parts.append(array_search)
 
             logger.debug(f"Returning parse san key {tag_values} and qp: {query_parts}")
-
             return tag_values, query_parts
         except Exception as exc:
             logger.warning(f"query not sanitized (maybe empty value), error is: {exc}")
-            return {}, {}
+            return [], []
 
     async def generate_query(self, tags) -> str:
         base_query = (

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -156,12 +156,13 @@ class Subscription:
 
             return updated_keys
         except Exception as e:
-            logger.error(f"An unexpected error occurred: {e}")
-            return None
+            logger.error(f"An unexpected error occurred: {e}", exc_info=True)
+            return updated_keys
 
     async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
         query_parts = []
         tag_values = []
+        logger.debug(f"parse san keys rec updatred keys = {updated_keys}")
 
         try:
             for item in updated_keys:
@@ -198,7 +199,7 @@ class Subscription:
             logger.debug(f"Returning parse san key {tag_values} and qp: {query_parts}")
             return tag_values, query_parts
         except Exception as exc:
-            logger.warning(f"query not sanitized (maybe empty value), error is: {exc}")
+            logger.warning(f"query not sanitized (maybe empty value) tv is {tag_values}, qp is {query_parts}, error is: {exc}", exc_info=True)
             return tag_values, query_parts
 
     async def generate_query(self, tags) -> str:
@@ -244,7 +245,7 @@ class Subscription:
             )
             return tag_values, query_parts
         else:
-            return None, {}
+            return {}, {}
 
     async def sub_response_builder(
         self, event_type, subscription_id, results_json, http_status_code

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -168,7 +168,7 @@ class Subscription:
             tag_values, query_parts = await self.parse_sanitized_keys(updated_keys, logger)
         return tag_values, query_parts
     
-    def sub_response_builder(self, event_type, subscription_id, results_json, http_status_code):
+    async def sub_response_builder(self, event_type, subscription_id, results_json, http_status_code):
         return JSONResponse(
                 content={
                     "event": event_type,

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -42,10 +42,10 @@ class Subscription:
             "sig",
         ]
 
-    async def generate_query(self):
-        base_query = f"SELECT * FROM events WHERE {self.where_clause};"
+    #async def generate_query(self):
+    #    base_query = f"SELECT * FROM events WHERE {self.where_clause};"
 
-    async def generate_tag_clause(self, tags, logger) -> str:
+    async def generate_tag_clause(self, tags) -> str:
         tag_clause = (
             " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
@@ -61,7 +61,7 @@ class Subscription:
                 filters.pop("limit")
             except:
                 logger.debug(f"No limit")
-            filters["limit"] = min(200, limit_var)
+            #filters["limit"] = min(200, limit_var)
 
             key_mappings = {
                 "authors": "pubkey",
@@ -124,7 +124,7 @@ class Subscription:
             logger.warning(f"query not sanitized (maybe empty value)")
             return {}, {}
 
-    async def generate_query(self, tags, logger) -> str:
+    async def generate_query(self, tags) -> str:
         base_query = (
             "EXISTS (SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
@@ -158,8 +158,8 @@ class Subscription:
         else:
             return None
 
-    async def parse_filters(self, filters: dict) -> tuple:
+    async def parse_filters(self, filters: dict, logger) -> tuple:
         updated_keys = await self.sanitize_event_keys(filters)
         if updated_keys:
-            tag_values, query_parts = await self.parse_sanitized_keys(updated_keys)
+            tag_values, query_parts = await self.parse_sanitized_keys(updated_keys, logger)
         return tag_values, query_parts

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -71,7 +71,7 @@ class Event:
         )
         await conn.commit()
 
-    async def evt_response(self, results_json, http_status_code):
+    def evt_response(self, results_json, http_status_code):
         response = {
             "event": "OK",
             "subscription_id": "n0stafarian419",
@@ -118,7 +118,7 @@ class Subscription:
             "sig",
         ]
 
-    async def generate_tag_clause(self, tags) -> str:
+    def generate_tag_clause(self, tags) -> str:
         tag_clause = (
             " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
@@ -207,14 +207,6 @@ class Subscription:
             )
             return tag_values, query_parts
 
-    async def generate_query(self, tags) -> str:
-        base_query = (
-            "EXISTS (SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
-        )
-        or_conditions = " OR ".join(f"elem @> '{tag}'" for tag in tags)
-        complete_query = base_query.format(or_conditions)
-        return complete_query
-
     async def _parser_worker(self, record, column_added) -> None:
         row_result = {}
         i = 0
@@ -234,7 +226,7 @@ class Subscription:
         except:
             return None
 
-    async def fetch_data_from_cache(self, redis_key, redis_client) -> bytes:
+    def fetch_data_from_cache(self, redis_key, redis_client) -> bytes:
         cached_data = redis_client.get(redis_key)
         if cached_data:
             return cached_data
@@ -252,14 +244,14 @@ class Subscription:
         else:
             return {}, {}, None
 
-    async def base_query_builder(self, tag_values, query_parts, limit, logger):
+    def base_query_builder(self, tag_values, query_parts, limit, logger):
         try:
             logger.debug(f"Base q builder, tg is {tag_values}, qp is {query_parts}")
             if query_parts:
                 self.where_clause = " AND ".join(query_parts)
 
             if tag_values:
-                tag_clause = await self.generate_tag_clause(tag_values)
+                tag_clause = self.generate_tag_clause(tag_values)
                 self.where_clause += f" AND {tag_clause}"
 
             if not limit:
@@ -272,7 +264,7 @@ class Subscription:
             logger.error(f"Error building query: {exc}", exc_info=True)
             return None
 
-    async def sub_response_builder(
+    def sub_response_builder(
         self, event_type, subscription_id, results_json, http_status_code
     ):
         return JSONResponse(

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -7,6 +7,7 @@ from logging.handlers import RotatingFileHandler
 import psycopg
 import redis
 import uvicorn
+
 from datadog import initialize, statsd
 from ddtrace import tracer
 from dotenv import load_dotenv
@@ -23,7 +24,6 @@ options = {"statsd_host": "172.28.0.5", "statsd_port": 8125}
 initialize(**options)
 
 redis_client = redis.Redis(host="172.28.0.6", port=6379)
-
 
 tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
@@ -178,9 +178,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         return return_response
 
                     else:
-                        redis_client.setex(
-                            str(subscription_obj.filters), 240, ""
-                        )
+                        redis_client.setex(str(subscription_obj.filters), 240, "")
                         return subscription_obj.sub_response_builder(
                             "EOSE", subscription_obj.subscription_id, "", 200
                         )

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -178,7 +178,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
         subscription_obj = Subscription(request_payload)
 
         if not subscription_obj.filters:
-            return subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 204)
+            return subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, "", 204)
 
         logger.debug(f"Fiters are: {subscription_obj.filters}")
         tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters, logger)
@@ -220,11 +220,11 @@ async def handle_subscription(request: Request) -> JSONResponse:
             logger.debug(f"parse_var var is {parse_var} and of type {type(parse_var)}")
             if not parse_var:
                 event_type = "EOSE"
-                results_json = None
+                results_json = ""
             return await subscription_obj.sub_response_builder(event_type, subscription_obj.subscription_id, results_json, 200)
 
         else:
-            return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
+            return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, "", 200)
 
     except psycopg.Error as exc:
         logger.error(f"Error occurred: {str(exc)}", exc_info=True)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -211,7 +211,15 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
     except Exception as exc:
         logger.error(f"General exception occurred: {exc}", exc_info=True)
-        return JSONResponse(content={"error": str(exc)}, status_code=500)
+        #return JSONResponse(content={"error": str(exc)}, status_code=500)
+        return JSONResponse(
+            content={
+                "event": event_type,
+                "subscription_id": subscription_obj.subscription_id,
+                "results_json": results_json,
+            },
+            status_code=500,
+        )
 
 
 if __name__ == "__main__":

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -107,7 +107,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
         created_at=event_dict["created_at"],
         tags=event_dict["tags"],
         content=event_dict["content"],
-        sig=event_dict.get["sig"],
+        sig=event_dict["sig"],
     )
 
     try:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -29,7 +29,7 @@ tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 log_file = "./logs/event_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -210,7 +210,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         return return_response
 
                     else:
-                        return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
+                        return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, "", 200)
 
         elif cached_results:
             event_type = "EVENT"

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -149,7 +149,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
             subscription_obj.filters, logger
         )
 
-        sql_query = await subscription_obj.base_query_builder(tag_values, query_parts)
+        sql_query = await subscription_obj.base_query_builder(tag_values, query_parts, logger)
         #logger.debug(f"Tag values: {tag_values} and query parts {query_parts} are: ")
         #if query_parts:
         #    where_clause = " AND ".join(query_parts)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -205,10 +205,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         serialized_events = json.dumps(parsed_results)
 
                         redis_client.setex(subscription_obj.filters, 240, serialized_events)
-                        return subscription_obj.sub_response_builder("EVENT", subscription_obj.subscription_id, serialized_events, 200)
+                        return await subscription_obj.sub_response_builder("EVENT", subscription_obj.subscription_id, serialized_events, 200)
 
                     else:
-                        return subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
+                        return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
 
         elif cached_results:
             event_type = "EVENT"
@@ -219,10 +219,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
             if not parse_var:
                 event_type = "EOSE"
                 results_json = None
-            return subscription_obj.sub_response_builder(event_type, subscription_obj.subscription_id, results_json, 200)
+            return await subscription_obj.sub_response_builder(event_type, subscription_obj.subscription_id, results_json, 200)
 
         else:
-            return subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
+            return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)
 
     except psycopg.Error as exc:
         logger.error(f"Error occurred: {str(exc)}", exc_info=True)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -204,9 +204,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         parsed_results = await subscription_obj.query_result_parser(listed)
                         serialized_events = json.dumps(parsed_results)
 
-                        redis_client.setex(subscription_obj.filters, 240, serialized_events)
+                        redis_client.setex(str(subscription_obj.filters), 240, serialized_events)
                         return_response = await subscription_obj.sub_response_builder("EVENT", subscription_obj.subscription_id, serialized_events, 200)
                         logger.debug(f"return response is {return_response} of type: {type({return_response})}, stringified is : {str(return_response)}")
+                        return return_response
 
                     else:
                         return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -15,6 +15,7 @@ import psycopg
 import redis
 import uvicorn
 from psycopg_pool import AsyncConnectionPool
+from docker_stuff.python_stuff.event_classes import Event, Subscription
 
 load_dotenv()
 
@@ -34,119 +35,6 @@ handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
-
-
-class Event:
-    def __init__(
-        self,
-        event_id: str,
-        pubkey: str,
-        kind: int,
-        created_at: int,
-        tags: List,
-        content: str,
-        sig: str,
-    ) -> None:
-        self.event_id = event_id
-        self.pubkey = pubkey
-        self.kind = kind
-        self.created_at = created_at
-        self.tags = tags
-        self.content = content
-        self.sig = sig
-
-    def __str__(self) -> str:
-        return f"{self.event_id}, {self.pubkey}, {self.kind}, {self.created_at}, {self.tags}, {self.content}, {self.sig} "
-
-
-async def generate_query(tags) -> str:
-    base_query = " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
-    conditions = []
-    for tag_pair in tags:
-        condition = f"elem @> '{json.dumps(tag_pair)}'"
-        conditions.append(condition)
-
-    complete_query = base_query.format(" OR ".join(conditions))
-    return complete_query
-
-
-async def sanitize_event_keys(filters) -> Dict:
-    try:
-        try:
-            filters.pop("limit")
-        except:
-            logger.debug(f"No limit")
-        logger.debug(f"Filter variable is: {filters} and of length {len(filters)}")
-
-        key_mappings = {
-            "authors": "pubkey",
-            "kinds": "kind",
-            "ids": "id",
-        }
-        updated_keys = {}
-        if len(filters) > 0:
-            for key in filters:
-                logger.debug(f"Key value is: {key}, {filters[key]}")
-    
-                new_key = key_mappings.get(key, key)
-                if new_key != key:
-                    stored_val = filters[key]
-                    updated_keys[new_key] = stored_val
-                    logger.debug(f"Adding new key {new_key} with value {stored_val}")
-                else:
-                    updated_keys[key] = filters[key]
-    
-        return updated_keys
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
-        return updated_keys
-
-
-async def parse_sanitized_query(updated_keys) -> Tuple[List, List]:
-    tag_values = []
-    query_parts = []
-    if len(updated_keys) < 0:
-        return {}, {}
-
-
-    for item in updated_keys:
-        outer_break = False
-
-        if item.startswith("#"):
-            logger.debug(
-                f"Tag key is: {item}, value is {updated_keys[item]} and of type: {type(updated_keys[item])}"
-            )
-
-            try:
-                for tags in updated_keys[item]:
-                    tag_value_pair = json.dumps([item[1], tags])
-                    logger.debug(f"Adding tag key value pair: {tag_value_pair}")
-                    tag_values.append(tag_value_pair)
-                    outer_break = True
-                    continue
-            except TypeError as e:
-                logger.error(f"Error processing tags for key {item}: {e}")
-
-        elif item in ["since", "until"]:
-            if item == "since":
-                q_part = f'created_at > {updated_keys["since"]}'
-                query_parts.append(q_part)
-                outer_break = True
-                continue
-            elif item == "until":
-                q_part = f'created_at < {updated_keys["until"]}'
-                query_parts.append(q_part)
-                outer_break = True
-                continue
-
-        if outer_break:
-            continue
-
-        q_part = f"{item} = ANY(ARRAY {updated_keys[item]})"
-        logger.debug(f"q_part is {q_part}")
-        query_parts.append(q_part)
-
-    return tag_values, query_parts
 
 
 def get_conn_str() -> str:
@@ -209,21 +97,18 @@ def initialize_db() -> None:
         return False
 
 
-
 @app.post("/new_event")
 async def handle_new_event(request: Request) -> JSONResponse:
     event_dict = await request.json()
     event_obj = Event(
-        event_id=event_dict.get("id", ""),
-        pubkey=event_dict.get("pubkey", ""),
-        kind=event_dict.get("kind", 0),
-        created_at=event_dict.get("created_at", 0),
-        tags=event_dict.get("tags", {}),
-        content=event_dict.get("content", ""),
-        sig=event_dict.get("sig", ""),
+        event_id=event_dict['id'],
+        pubkey=event_dict['pubkey'],
+        kind=event_dict['kind'],
+        created_at=event_dict['created_at'],
+        tags=event_dict['tags'],
+        content=event_dict['content'],
+        sig=event_dict.get['sig'],
     )
-
-    logger.debug(f"Created event object {event_obj}")
 
     try:
         delete_message = None
@@ -286,83 +171,34 @@ async def handle_new_event(request: Request) -> JSONResponse:
             logger.debug(delete_message.format(pubkey=event_obj.pubkey))
 
 
-async def generate_query(tags) -> str:
-    base_query = "EXISTS (SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
-    or_conditions = " OR ".join(f"elem @> '{tag}'" for tag in tags)
-    complete_query = base_query.format(or_conditions)
-    return complete_query
-
-
-async def parser_worker(record, column_added) -> None:
-    column_names = ["id", "pubkey", "kind", "created_at", "tags", "content", "sig"]
-    row_result = {}
-    i = 0
-    for item in record:
-        row_result[column_names[i]] = item
-        i += 1
-    column_added.append([row_result])
-
-
-async def query_result_parser(query_result) -> List:
-    column_added = []
-    tasks = []
-    if query_result:
-        for record in query_result:
-            tasks.append(parser_worker(record, column_added))
-    
-        await asyncio.gather(*tasks)
-    
-        return column_added
-    else:
-        return None
-
-async def fetch_data_from_cache(redis_key):
-    cached_data = redis_client.get(redis_key)
-    logger.debug(f"Cached data is:{cached_data} and of type: {type(cached_data)}")
-    if cached_data:
-        return cached_data
-    else:
-        return None
-
-#
-async def parse_filters(filters: dict) -> tuple:
-    updated_keys = await sanitize_event_keys(filters)
-    tag_values = {}
-    query_parts = []
-    if updated_keys:
-        tag_values, query_parts = await parse_sanitized_query(updated_keys)
-    return tag_values, query_parts
-
-
 @app.post("/subscription")
 async def handle_subscription(request: Request) -> JSONResponse:
     try:
-        payload = await request.json()
-        filters = payload.get("event_dict", {})
-        subscription_id = payload.get("subscription_id", "")
+        request_payload = await request.json()
+        subscription_obj = Subscription(request_payload)
 
-        if not filters:
+        if not subscription_obj.filters:
             return JSONResponse(
                 content={
                     "event": "EOSE",
-                    "subscription_id": subscription_id,
+                    "subscription_id": subscription_obj.subscription_id,
                     "results_json": "None",
                 },
-                status_code=204
+                status_code=204,
             )
 
-        tag_values, query_parts = await parse_filters(filters)
+        tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters)
         where_clause = " AND ".join(query_parts)
 
         if tag_values:
-            tag_clause = await generate_query(tag_values)
+            tag_clause = await subscription_obj.generate_query(tag_values)
             where_clause += f" AND {tag_clause}"
 
         sql_query = f"SELECT * FROM events WHERE {where_clause} LIMIT 100;"
         logger.debug(f"SQL query constructed: {sql_query}")
 
-        redis_key = f"{sql_query}"
-        cached_results = await fetch_data_from_cache(redis_key)
+        redis_key = f"{subscription_obj.filters}"
+        cached_results = await subscription_obj.fetch_data_from_cache(redis_key)
 
         if cached_results is None:
             async with app.async_pool.connection() as conn:
@@ -370,31 +206,31 @@ async def handle_subscription(request: Request) -> JSONResponse:
                     await cur.execute(query=sql_query)
                     listed = await cur.fetchall()
                     if listed:
-
-                        parsed_results = await query_result_parser(listed)
+                        parsed_results = await subscription_obj.query_result_parser(listed)
                         serialized_events = json.dumps(parsed_results)
-                        
+
                         redis_client.setex(redis_key, 240, serialized_events)
                         return JSONResponse(
                             content={
                                 "event": "EVENT",
-                                "subscription_id": subscription_id,
+                                "subscription_id": subscription_obj.subscription_id,
                                 "results_json": serialized_events,
                             },
-                            status_code=200)
+                            status_code=200,
+                        )
                     else:
                         JSONResponse(
                             content={
                                 "event": "EOSE",
-                                "subscription_id": subscription_id,
+                                "subscription_id": subscription_obj.subscription_id,
                                 "results_json": None,
                             },
-                            status_code=200)
-
+                            status_code=200,
+                        )
 
         elif cached_results:
             event_type = "EVENT"
-            parse_var = json.loads(cached_results.decode('utf-8'))
+            parse_var = json.loads(cached_results.decode("utf-8"))
             logger.debug(f" parsed var is : {parse_var}")
             results_json = json.dumps(parse_var)
             logger.debug(f"parse_var var is {parse_var} and of type {type(parse_var)}")
@@ -404,19 +240,19 @@ async def handle_subscription(request: Request) -> JSONResponse:
             return JSONResponse(
                 content={
                     "event": event_type,
-                    "subscription_id": subscription_id,
+                    "subscription_id": subscription_obj.subscription_id,
                     "results_json": results_json,
                 },
-                status_code=200
+                status_code=200,
             )
         else:
             return JSONResponse(
                 content={
                     "event": "EOSE",
-                    "subscription_id": subscription_id,
+                    "subscription_id": subscription_obj.subscription_id,
                     "results_json": "None",
                 },
-                status_code=200
+                status_code=200,
             )
 
     except psycopg.Error as exc:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -113,11 +113,11 @@ async def handle_new_event(request: Request) -> JSONResponse:
     try:
         async with request.app.async_pool.connection() as conn:
             async with conn.cursor() as cur:
-                event_obj.delete_check
+                
                 if event_obj.kind in {0, 3}:
-                    event_obj.delete_check(conn, cur, statsd)
+                    await event_obj.delete_check(conn, cur, statsd)
 
-                event_obj.add_event(conn, cur)
+                await event_obj.add_event(conn, cur)
                 statsd.increment("nostr.event.added.count", tags=["func:new_event"])
                 return await event_obj.evt_response("true", 200)
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -29,7 +29,7 @@ tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 log_file = "./logs/event_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -186,12 +186,12 @@ async def handle_subscription(request: Request) -> JSONResponse:
                 },
                 status_code=204,
             )
-
+        logger.debug(f"Fiters are: {subscription_obj.filters}")
         tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters, logger)
         where_clause = " AND ".join(query_parts)
 
         if tag_values:
-            tag_clause = await subscription_obj.generate_query(tag_values)
+            tag_clause = await subscription_obj.generate_tag_clause(tag_values)
             where_clause += f" AND {tag_clause}"
 
         sql_query = f"SELECT * FROM events WHERE {where_clause} LIMIT 100;"

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -205,7 +205,8 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         serialized_events = json.dumps(parsed_results)
 
                         redis_client.setex(subscription_obj.filters, 240, serialized_events)
-                        return await subscription_obj.sub_response_builder("EVENT", subscription_obj.subscription_id, serialized_events, 200)
+                        return_response = await subscription_obj.sub_response_builder("EVENT", subscription_obj.subscription_id, serialized_events, 200)
+                        logger.debug(f"return response is {return_response} of type: {type({return_response})}, stringified is : {str(return_response)}")
 
                     else:
                         return await subscription_obj.sub_response_builder("EOSE", subscription_obj.subscription_id, None, 200)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -178,14 +178,20 @@ async def handle_subscription(request: Request) -> JSONResponse:
                         return return_response
 
                     else:
+                        redis_client.setex(
+                            str(subscription_obj.filters), 240, {}
+                        )
                         return subscription_obj.sub_response_builder(
                             "EOSE", subscription_obj.subscription_id, "", 200
                         )
 
         elif cached_results:
             event_type = "EVENT"
-            parse_var = json.loads(cached_results.decode("utf-8"))
-            results_json = json.dumps(parse_var)
+            try:
+                parse_var = json.loads(cached_results.decode("utf-8"))
+                results_json = json.dumps(parse_var)
+            except:
+                logger.warning("Empty cache results, sending EOSE")
             if not parse_var:
                 event_type = "EOSE"
                 results_json = ""

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -358,7 +358,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
             tag_clause = await generate_query(tag_values)
             where_clause += f" AND {tag_clause}"
 
-        sql_query = f"SELECT * FROM events WHERE {where_clause};"
+        sql_query = f"SELECT * FROM events WHERE {where_clause} LIMIT 100;"
         logger.debug(f"SQL query constructed: {sql_query}")
 
         redis_key = f"{sql_query}"

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -188,6 +188,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
             )
         logger.debug(f"Fiters are: {subscription_obj.filters}")
         tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters, logger)
+        logger.debug(f"Tag values: {tag_values} and query parts {query_parts} are: ")
         where_clause = " AND ".join(query_parts)
 
         if tag_values:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -179,7 +179,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
                     else:
                         redis_client.setex(
-                            str(subscription_obj.filters), 240, {}
+                            str(subscription_obj.filters), 240, ""
                         )
                         return subscription_obj.sub_response_builder(
                             "EOSE", subscription_obj.subscription_id, "", 200

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -193,7 +193,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
         logger.debug(f"SQL query constructed: {sql_query}")
 
         #redis_key = f"{subscription_obj.filters}"
-        cached_results = await subscription_obj.fetch_data_from_cache(subscription_obj.filters, redis_client)
+        cached_results = await subscription_obj.fetch_data_from_cache(str(subscription_obj.filters), redis_client)
 
         if cached_results is None:
             async with app.async_pool.connection() as conn:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -198,7 +198,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
         logger.debug(f"SQL query constructed: {sql_query}")
 
         redis_key = f"{subscription_obj.filters}"
-        cached_results = await subscription_obj.fetch_data_from_cache(redis_key)
+        cached_results = await subscription_obj.fetch_data_from_cache(redis_key, redis_client)
 
         if cached_results is None:
             async with app.async_pool.connection() as conn:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -187,7 +187,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
                 status_code=204,
             )
 
-        tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters)
+        tag_values, query_parts = await subscription_obj.parse_filters(subscription_obj.filters, logger)
         where_clause = " AND ".join(query_parts)
 
         if tag_values:

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -149,7 +149,8 @@ async def handle_subscription(request: Request) -> JSONResponse:
             subscription_obj.filters, logger
         )
         logger.debug(f"Tag values: {tag_values} and query parts {query_parts} are: ")
-        where_clause = " AND ".join(query_parts)
+        if query_parts:
+            where_clause = " AND ".join(query_parts)
 
         if tag_values:
             tag_clause = await subscription_obj.generate_tag_clause(tag_values)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -15,7 +15,7 @@ import psycopg
 import redis
 import uvicorn
 from psycopg_pool import AsyncConnectionPool
-from docker_stuff.python_stuff.event_classes import Event, Subscription
+from event_classes import Event, Subscription
 
 load_dotenv()
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -179,11 +179,8 @@ class ExtractedResponse:
 #
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
-        return ast.literal_eval(stripped)
-        #logger.debug(
-        #    f"Client response loop iter is {client_response} and of type {type(client_response)}"
-        #)
-        #events_to_send.append(client_response)
+        return json.loads(stripped)
+        #return ast.literal_eval(stripped)
 
     async def format_response(self):
         """

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -160,7 +160,9 @@ class ExtractedResponse:
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
-            logger.error(f"Error decoding JSON message in Extracted REsponse: {json_error}")
+            logger.error(
+                f"Error decoding JSON message in Extracted REsponse: {json_error}"
+            )
             self.results = ""
 
         self.comment = ""
@@ -176,14 +178,15 @@ class ExtractedResponse:
             "false",
             "duplicate: already have this event",
         )
-#
+
+    #
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
-        #logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
-        #return json.loads(stripped)
+        # logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
+        # return json.loads(stripped)
         stripped = stripped.replace("'", '"')
         return json.loads(stripped)
-        #return ast.literal_eval(stripped)
+        # return ast.literal_eval(stripped)
 
     async def format_response(self):
         """
@@ -196,7 +199,10 @@ class ExtractedResponse:
         if self.event_type == "EVENT":
             tasks = [self._process_event(event_result) for event_result in self.results]
             parsed_results = await asyncio.gather(*tasks)
-            events_to_send = [(self.event_type, self.subscription_id, result) for result in parsed_results]
+            events_to_send = [
+                (self.event_type, self.subscription_id, result)
+                for result in parsed_results
+            ]
             return events_to_send
         elif self.event_type == "OK":
             client_response: Tuple[str, Optional[str], str, Optional[str]] = (
@@ -275,6 +281,7 @@ client_ips = []
 import websockets.exceptions
 from aiohttp.client_exceptions import ClientConnectionError
 
+
 async def handle_websocket_connection(
     websocket: websockets.WebSocketServerProtocol,
 ) -> None:
@@ -294,7 +301,7 @@ async def handle_websocket_connection(
                 except json.JSONDecodeError as json_error:
                     logger.error(f"Error decoding JSON message: {json_error}")
                     continue  # Skip processing this message
-                
+
                 logger.debug(f"UUID = {ws_message.uuid}")
                 statsd.increment(
                     "nostr.new_connection.count",
@@ -332,21 +339,27 @@ async def handle_websocket_connection(
                     await websocket.send(json.dumps(response))
 
         except websockets.exceptions.ConnectionClosedError as close_error:
-            logger.error(f"WebSocket connection closed unexpectedly: {close_error}", exc_info=True)
+            logger.error(
+                f"WebSocket connection closed unexpectedly: {close_error}",
+                exc_info=True,
+            )
             # Optionally retry the connection or handle the closure gracefully
 
         except ClientConnectionError as connection_error:
-            logger.error(f"Connection error occurred: {connection_error}", exc_info=True)
+            logger.error(
+                f"Connection error occurred: {connection_error}", exc_info=True
+            )
             # Optionally retry the connection or handle the error gracefully
-            
+
         except aiohttp.ClientError as client_error:
             logger.error(f"HTTP client error occurred: {client_error}", exc_info=True)
             # Handle HTTP client errors as needed
 
         except Exception as e:
-            logger.error(f"Error occurred while processing WebSocket message: {e}", exc_info=True)
+            logger.error(
+                f"Error occurred while processing WebSocket message: {e}", exc_info=True
+            )
             # Add any necessary handling for other exceptions here
-
 
 
 async def send_event_to_handler(
@@ -409,7 +422,6 @@ async def send_subscription_to_handler(
             return
         response_object = ExtractedResponse(response_data=response_data)
 
-
         logger.debug(f"Response received as: {response_data}")
         EOSE: Tuple[str, Optional[str]] = "EOSE", response_object.subscription_id
 
@@ -424,7 +436,7 @@ async def send_subscription_to_handler(
 
 
 if __name__ == "__main__":
-    #gitrate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=30000)
+    # gitrate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=30000)
 
     try:
         start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -1,4 +1,3 @@
-import ast
 import hashlib
 import json
 import logging

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -164,7 +164,7 @@ class ExtractedResponse:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
             logger.error(
-                f"Error decoding JSON message in Extracted REsponse: {json_error}. The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])})} "
+                f"Error decoding JSON message in Extracted REsponse: {json_error}. The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])}) "
             )
             self.results = ""
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -184,9 +184,9 @@ class ExtractedResponse:
             self.subscription_id,
             ast.literal_eval(stripped),
         )
-        logger.debug(
-            f"Client response loop iter is {client_response} and of type {type(client_response)}"
-        )
+        #logger.debug(
+        #    f"Client response loop iter is {client_response} and of type {type(client_response)}"
+        #)
         events_to_send.append(client_response)
 
     async def format_response(self):

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -438,6 +438,7 @@ async def send_subscription_to_handler(
             await websocket.send(json.dumps(EOSE))
         else:
             await websocket.send(json.dumps(EOSE))
+            await websocket.send(json.dumps("CLOSED", subscription_id, "I don't have any response"))
             logger.debug(f"Response data is {response_data} but it failed")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -279,9 +279,9 @@ async def handle_websocket_connection(
     websocket: websockets.WebSocketServerProtocol,
 ) -> None:
     global unique_sessions, client_ips
-
+    conn = aiohttp.TCPConnector(limit=500)
     # Create a single aiohttp session per WebSocket connection
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(connector=conn) as session:
         try:
             async for message in websocket:
                 try:

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -179,7 +179,7 @@ class ExtractedResponse:
 #
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
-        logger.debug(f"Stripped var is {stripped} and of type : {type(stripped)}")
+        logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
         #return json.loads(stripped)
         return ast.literal_eval(stripped)
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -339,8 +339,9 @@ async def handle_websocket_connection(
                     )
                 elif ws_message.event_type == "CLOSE":
                     response: Tuple[str, str] = (
-                        "NOTICE",
-                        f"closing {ws_message.subscription_id}",
+                        "CLOSED",
+                        ws_message.subscription_id
+                        #f"closing {ws_message.subscription_id}",
                     )
                     await websocket.send(json.dumps(response))
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -185,6 +185,7 @@ class ExtractedResponse:
     #
     async def _process_event(self, event_result):
         try:
+            logger.debug(f"event_result var is {event_result}")
             stripped = str(event_result)[1:-1]
             logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
             # return json.loads(stripped)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -165,7 +165,8 @@ class ExtractedResponse:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
             logger.error(
-                f"Error decoding JSON message in Extracted REsponse: {json_error}.")# The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])}) "
+                f"Error decoding JSON message in Extracted REsponse: {json_error}."
+            )  # The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])}) "
 
             self.results = ""
 
@@ -190,14 +191,15 @@ class ExtractedResponse:
             stripped = str(event_result)[1:-1]
             logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
             # return json.loads(stripped)
-            #stripped = stripped.replace("'", '"')
+            # stripped = stripped.replace("'", '"')
             logger.debug(f"Returning stripped {stripped}")
-            #return json.loads(stripped)
+            # return json.loads(stripped)
             return ast.literal_eval(stripped)
         except Exception as exc:
-            logger.error(f"Process events exc is {exc}", exc_info=True )
+            logger.error(f"Process events exc is {exc}", exc_info=True)
             return ""
-        # 
+        #
+
     async def format_response(self):
         """
         Formats the response based on the event type.
@@ -288,8 +290,6 @@ unique_sessions = []
 client_ips = []
 
 
-
-
 async def handle_websocket_connection(
     websocket: websockets.WebSocketServerProtocol,
 ) -> None:
@@ -344,7 +344,7 @@ async def handle_websocket_connection(
                         "CLOSED",
                         ws_message.subscription_id,
                         "error: shutting down idle subscription"
-                        #f"closing {ws_message.subscription_id}",
+                        # f"closing {ws_message.subscription_id}",
                     )
                     await websocket.send(json.dumps(response))
 
@@ -354,22 +354,18 @@ async def handle_websocket_connection(
                 exc_info=True,
             )
 
-
         except ClientConnectionError as connection_error:
             logger.error(
                 f"Connection error occurred: {connection_error}", exc_info=True
             )
 
-
         except aiohttp.ClientError as client_error:
             logger.error(f"HTTP client error occurred: {client_error}", exc_info=True)
-
 
         except Exception as e:
             logger.error(
                 f"Error occurred while processing WebSocket message: {e}", exc_info=True
             )
-
 
 
 async def send_event_to_handler(
@@ -442,7 +438,15 @@ async def send_subscription_to_handler(
             await websocket.send(json.dumps(EOSE))
         else:
             await websocket.send(json.dumps(EOSE))
-            await websocket.send(json.dumps(("CLOSED", subscription_id, "unsupported: filter contains unknown elements")))
+            await websocket.send(
+                json.dumps(
+                    (
+                        "CLOSED",
+                        subscription_id,
+                        "unsupported: filter contains unknown elements",
+                    )
+                )
+            )
             logger.debug(f"Response data is {response_data} but it failed")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -179,6 +179,7 @@ class ExtractedResponse:
 #
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
+        logger.debug(f"Stripped var is {stripped} and of type : {type(stripped)}")
         return json.loads(stripped)
         #return ast.literal_eval(stripped)
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -340,7 +340,8 @@ async def handle_websocket_connection(
                 elif ws_message.event_type == "CLOSE":
                     response: Tuple[str, str] = (
                         "CLOSED",
-                        ws_message.subscription_id
+                        ws_message.subscription_id,
+                        f"Closing {ws_message.subscription_id}"
                         #f"closing {ws_message.subscription_id}",
                     )
                     await websocket.send(json.dumps(response))
@@ -439,7 +440,7 @@ async def send_subscription_to_handler(
             await websocket.send(json.dumps(EOSE))
         else:
             await websocket.send(json.dumps(EOSE))
-            await websocket.send(json.dumps("CLOSED", subscription_id, "I don't have any response"))
+            await websocket.send(json.dumps(("CLOSED", subscription_id, "I don't have any response")))
             logger.debug(f"Response data is {response_data} but it failed")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -24,7 +24,7 @@ initialize(**options)
 tracer.configure(hostname="172.28.0.5", port=8126)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 log_file: str = "./logs/websocket_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -164,7 +164,7 @@ class ExtractedResponse:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
             logger.error(
-                f"Error decoding JSON message in Extracted REsponse: {json_error}"
+                f"Error decoding JSON message in Extracted REsponse: {json_error}. The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])})} "
             )
             self.results = ""
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -451,7 +451,7 @@ async def send_subscription_to_handler(
 
 
 if __name__ == "__main__":
-    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=30000)
+    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=300)
 
     try:
         start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -179,7 +179,7 @@ class ExtractedResponse:
 #
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
-        logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
+        #logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
         #return json.loads(stripped)
         stripped = stripped.replace("'", '"')
         return json.loads(stripped)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -190,7 +190,7 @@ class ExtractedResponse:
             stripped = str(event_result)[1:-1]
             logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
             # return json.loads(stripped)
-            stripped = stripped.replace("'", '"')
+            #stripped = stripped.replace("'", '"')
             logger.debug(f"Returning stripped {stripped}")
             #return json.loads(stripped)
             return ast.literal_eval(stripped)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -295,7 +295,6 @@ async def handle_websocket_connection(
 ) -> None:
     global unique_sessions, client_ips
     conn = aiohttp.TCPConnector(limit=500)
-    # Create a single aiohttp session per WebSocket connection
     async with aiohttp.ClientSession(connector=conn) as session:
         try:
             async for message in websocket:
@@ -344,7 +343,6 @@ async def handle_websocket_connection(
                         "CLOSED",
                         ws_message.subscription_id,
                         "error: shutting down idle subscription"
-                        # f"closing {ws_message.subscription_id}",
                     )
                     await websocket.send(json.dumps(response))
 
@@ -429,7 +427,7 @@ async def send_subscription_to_handler(
         response_object = ExtractedResponse(response_data=response_data)
 
         logger.debug(f"Response received as: {response_data}")
-        EOSE: Tuple[str, Optional[str]] = "EOSE", response_object.subscription_id
+        EOSE = "EOSE", response_object.subscription_id
 
         if response.status == 200 and response_object.event_type == "EVENT":
             response_list = await response_object.format_response()
@@ -438,15 +436,6 @@ async def send_subscription_to_handler(
             await websocket.send(json.dumps(EOSE))
         else:
             await websocket.send(json.dumps(EOSE))
-            await websocket.send(
-                json.dumps(
-                    (
-                        "CLOSED",
-                        subscription_id,
-                        "unsupported: filter contains unknown elements",
-                    )
-                )
-            )
             logger.debug(f"Response data is {response_data} but it failed")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -164,8 +164,8 @@ class ExtractedResponse:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
             logger.error(
-                f"Error decoding JSON message in Extracted REsponse: {json_error}. The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])}) "
-            )
+                f"Error decoding JSON message in Extracted REsponse: {json_error}.")# The json results were {response_data["results_json"]} of troy {type(response_data["results_json"])}) "
+
             self.results = ""
 
         self.comment = ""

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -341,7 +341,7 @@ async def handle_websocket_connection(
                     response: Tuple[str, str] = (
                         "CLOSED",
                         ws_message.subscription_id,
-                        f"Closing {ws_message.subscription_id}"
+                        "error: shutting down idle subscription"
                         #f"closing {ws_message.subscription_id}",
                     )
                     await websocket.send(json.dumps(response))
@@ -440,7 +440,7 @@ async def send_subscription_to_handler(
             await websocket.send(json.dumps(EOSE))
         else:
             await websocket.send(json.dumps(EOSE))
-            await websocket.send(json.dumps(("CLOSED", subscription_id, "I don't have any response")))
+            await websocket.send(json.dumps(("CLOSED", subscription_id, "unsupported: filter contains unknown elements")))
             logger.debug(f"Response data is {response_data} but it failed")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -451,7 +451,7 @@ async def send_subscription_to_handler(
 
 
 if __name__ == "__main__":
-    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=300)
+    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=500)
 
     try:
         start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -12,6 +12,10 @@ import websockets
 from datadog import initialize, statsd
 from ddtrace import tracer
 
+
+import websockets.exceptions
+from aiohttp.client_exceptions import ClientConnectionError
+
 options: Dict[str, Any] = {"statsd_host": "172.28.0.5", "statsd_port": 8125}
 
 initialize(**options)
@@ -19,7 +23,7 @@ initialize(**options)
 tracer.configure(hostname="172.28.0.5", port=8126)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 log_file: str = "./logs/websocket_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
@@ -277,8 +281,6 @@ unique_sessions = []
 client_ips = []
 
 
-import websockets.exceptions
-from aiohttp.client_exceptions import ClientConnectionError
 
 
 async def handle_websocket_connection(
@@ -342,23 +344,23 @@ async def handle_websocket_connection(
                 f"WebSocket connection closed unexpectedly: {close_error}",
                 exc_info=True,
             )
-            # Optionally retry the connection or handle the closure gracefully
+
 
         except ClientConnectionError as connection_error:
             logger.error(
                 f"Connection error occurred: {connection_error}", exc_info=True
             )
-            # Optionally retry the connection or handle the error gracefully
+
 
         except aiohttp.ClientError as client_error:
             logger.error(f"HTTP client error occurred: {client_error}", exc_info=True)
-            # Handle HTTP client errors as needed
+
 
         except Exception as e:
             logger.error(
                 f"Error occurred while processing WebSocket message: {e}", exc_info=True
             )
-            # Add any necessary handling for other exceptions here
+
 
 
 async def send_event_to_handler(

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -181,7 +181,9 @@ class ExtractedResponse:
         stripped = str(event_result)[1:-1]
         logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
         #return json.loads(stripped)
-        return ast.literal_eval(stripped)
+        stripped = stripped.replace("'", '"')
+        return json.loads(stripped)
+        #return ast.literal_eval(stripped)
 
     async def format_response(self):
         """

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -184,11 +184,16 @@ class ExtractedResponse:
 
     #
     async def _process_event(self, event_result):
-        stripped = str(event_result)[1:-1]
-        # logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
-        # return json.loads(stripped)
-        stripped = stripped.replace("'", '"')
-        return json.loads(stripped)
+        try:
+            stripped = str(event_result)[1:-1]
+            logger.info(f"Stripped var is {stripped} and of type : {type(stripped)}")
+            # return json.loads(stripped)
+            stripped = stripped.replace("'", '"')
+            logger.debug(f"Returning stripped {stripped}")
+            return json.loads(stripped)
+        except Exception as exc:
+            logger.error(f"Process events exc is {exc}", exc_info=True )
+            return ""
         # return ast.literal_eval(stripped)
 
     async def format_response(self):

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import ast
 import logging
 from collections import defaultdict
 from logging.handlers import RotatingFileHandler
@@ -191,12 +192,12 @@ class ExtractedResponse:
             # return json.loads(stripped)
             stripped = stripped.replace("'", '"')
             logger.debug(f"Returning stripped {stripped}")
-            return json.loads(stripped)
+            #return json.loads(stripped)
+            return ast.literal_eval(stripped)
         except Exception as exc:
             logger.error(f"Process events exc is {exc}", exc_info=True )
             return ""
-        # return ast.literal_eval(stripped)
-
+        # 
     async def format_response(self):
         """
         Formats the response based on the event type.

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -180,8 +180,8 @@ class ExtractedResponse:
     async def _process_event(self, event_result):
         stripped = str(event_result)[1:-1]
         logger.debug(f"Stripped var is {stripped} and of type : {type(stripped)}")
-        return json.loads(stripped)
-        #return ast.literal_eval(stripped)
+        #return json.loads(stripped)
+        return ast.literal_eval(stripped)
 
     async def format_response(self):
         """


### PR DESCRIPTION
## v0.7
**Enhancements**
* Re-added redis cache to serve frequent queries faster
* Added event classes to `event_handler` service for readability and portability
* More efficient use of coroutines
  * Use `asyncio.gather` to prepare and send responses to websocket client
  * Converted async methods to sync methods where appropriate to reduce overhead
* Added auto-multiline log detection for Datadog agent to more easily read stack traces
* Cleaned up noisy `DEBUG` log lines
* Better error handling for empty responses

**Bug Fixes**
* Fixed `websocket_handler` JSON loads error that occurred when loading empty payloads to no longer restart the websocket server
  * Server continues and maintains the websocket connection