### PR TITLE
Add NIP-50 Search capability and NIP-09 Event Deletion 

### DIFF
--- a/docker_stuff/dbm_setup.py
+++ b/docker_stuff/dbm_setup.py
@@ -7,31 +7,33 @@ load_dotenv()
 GREEN = "\033[0;32m"
 RED = "\033[0;31m"
 RESET = "\033[0m"
-DD_ROLE_PASSWORD = os.getenv('DD_ROLE_PASSWORD')
-DD_ROLE_NAME = os.getenv('DD_ROLE_NAME')
+DD_ROLE_PASSWORD = os.getenv("DD_ROLE_PASSWORD")
+DD_ROLE_NAME = os.getenv("DD_ROLE_NAME")
 
 
 def print_error(message):
     print(f"{RED}{message}{RESET}")
 
+
 def print_success(message):
     print(f"{GREEN}{message}{RESET}")
 
+
 def get_connection_params():
     return {
-        'host': os.getenv('PGHOST'),
-        'port': os.getenv('PGPORT'),
-        'dbname ': os.getenv('PGDATABASE '),
-        'user': os.getenv('DB_USER'),
-        'password': os.getenv('PGPASSWORD')
+        "host": os.getenv("PGHOST"),
+        "port": os.getenv("PGPORT"),
+        "dbname ": os.getenv("PGDATABASE "),
+        "user": os.getenv("DB_USER"),
+        "password": os.getenv("PGPASSWORD"),
     }
+
 
 def get_version(conn):
     try:
         with conn.cursor() as cur:
-            #version2 = cur.execute("SELECT VERSION();")
             cur.execute("SHOW SERVER_VERSION;")
-            version = float(str(cur.fetchone()[0].split(' ')[0])[0:3])
+            version = float(str(cur.fetchone()[0].split(" ")[0])[0:3])
     except psycopg2.Error as exc:
         print(f"Error determining version: {exc}")
     return version
@@ -43,12 +45,16 @@ def create_datadog_user_and_schema(conn, db, version):
             cur.execute(f"SELECT 1 FROM pg_roles WHERE rolname='{DD_ROLE_NAME}'")
             exists = cur.fetchone()
             if not exists:
-                cur.execute(f"CREATE USER {DD_ROLE_NAME} WITH PASSWORD '{DD_ROLE_PASSWORD}'")
+                cur.execute(
+                    f"CREATE USER {DD_ROLE_NAME} WITH PASSWORD '{DD_ROLE_PASSWORD}'"
+                )
                 print_success(f"{DD_ROLE_NAME} user created in {db} database")
                 conn.commit()
 
         with conn.cursor() as cur:
-            cur.execute(f"SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = '{DD_ROLE_NAME}')")
+            cur.execute(
+                f"SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = '{DD_ROLE_NAME}')"
+            )
             schema_exists = cur.fetchone()[0]
     except Exception as exc:
         print_error(f"An error occurred while querying for schema {exc}")
@@ -61,22 +67,34 @@ def create_datadog_user_and_schema(conn, db, version):
             print(f"Preparing postgres version {version}")
             if version >= 15:
                 cur.execute(f"ALTER ROLE {DD_ROLE_NAME} INHERIT;")
-                cur.execute(f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT pg_monitor TO {DD_ROLE_NAME};")
+                cur.execute(
+                    f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT pg_monitor TO {DD_ROLE_NAME};"
+                )
             elif version < 15 and version >= 10:
-                cur.execute(f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT pg_monitor TO {DD_ROLE_NAME};")
+                cur.execute(
+                    f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT pg_monitor TO {DD_ROLE_NAME};"
+                )
             elif version < 10:
-                cur.execute(f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT SELECT ON pg_stat_database TO {DD_ROLE_NAME}; CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")
-            
-            print_success(f"datadog schema created and permissions granted in {db} database")
+                cur.execute(
+                    f"CREATE SCHEMA datadog; GRANT USAGE ON SCHEMA datadog TO {DD_ROLE_NAME}; GRANT USAGE ON SCHEMA public TO {DD_ROLE_NAME}; GRANT SELECT ON pg_stat_database TO {DD_ROLE_NAME}; CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
+                )
+
+            print_success(
+                f"datadog schema created and permissions granted in {db} database"
+            )
             conn.commit()
     except Exception as e:
-        print_error(f"An error occurred while creating datadog schema and granting permissions: {e}")
+        print_error(
+            f"An error occurred while creating datadog schema and granting permissions: {e}"
+        )
+
 
 def explain_statement(conn, version):
     if version >= 10 and version <= 15:
         try:
             with conn.cursor() as cur:
-                cur.execute("""
+                cur.execute(
+                    """
                 CREATE OR REPLACE FUNCTION datadog.explain_statement(
                     l_query TEXT,
                     OUT explain JSON
@@ -96,15 +114,17 @@ def explain_statement(conn, version):
                 LANGUAGE 'plpgsql'
                 RETURNS NULL ON NULL INPUT
                 SECURITY DEFINER;
-                """)
+                """
+                )
                 conn.commit()
             print_success("Explain plans statement completed")
         except Exception as exc:
             print_error(f"Error encountered creating explain statement: {exc}")
-    elif  version < 10:
+    elif version < 10:
         try:
             with conn.cursor() as cur:
-                cur.execute("""
+                cur.execute(
+                    """
                 CREATE OR REPLACE FUNCTION datadog.pg_stat_activity() RETURNS SETOF pg_stat_activity AS
                   $$ SELECT * FROM pg_catalog.pg_stat_activity; $$
                 LANGUAGE sql
@@ -113,7 +133,8 @@ def explain_statement(conn, version):
                     $$ SELECT * FROM pg_stat_statements; $$
                 LANGUAGE sql
                 SECURITY DEFINER;
-                """)
+                """
+                )
                 conn.commit()
             print_success("Explain plans statement completed")
         except Exception as exc:
@@ -124,7 +145,9 @@ def create_pg_stat_statements_extension(conn_obj):
     try:
         with conn_obj.cursor() as cur:
             # Check if pg_stat_statements is already installed
-            cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements';")
+            cur.execute(
+                "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements';"
+            )
             result = cur.fetchone()
 
             if not result:
@@ -137,7 +160,9 @@ def create_pg_stat_statements_extension(conn_obj):
     except psycopg2.Error as e:
         print(f"{RED}Error installing pg_stat_statements extension: {e}")
 
+
 successful_setup = []
+
 
 def check_postgres_stats(conn_obj, db):
     try:
@@ -154,22 +179,28 @@ def check_postgres_stats(conn_obj, db):
             cur.execute("SELECT 1 FROM pg_stat_statements LIMIT 1;")
             print(f"{GREEN}Postgres pg_stat_statements read OK in {db}")
         successful_setup.append(db_name)
-        print(f"{RED}\n############### Moving On... to next database ###############################\n{RESET}")
-        
+        print(
+            f"{RED}\n############### Moving On... to next database ###############################\n{RESET}"
+        )
+
     except psycopg2.OperationalError as exc:
         print(f"{RED}Error querying pg_stats from{db}{RESET}: {exc}")
     except psycopg2.Error:
         print(f"{RED}Error while accessing Postgres statistics in {db}{RESET}")
 
+
 def list_databases(conn):
     try:
         with conn.cursor() as cur:
             cur.execute("SELECT datname FROM pg_database WHERE datistemplate = false")
-            databases = [row[0] for row in cur.fetchall() if not row[0].startswith('template')]
+            databases = [
+                row[0] for row in cur.fetchall() if not row[0].startswith("template")
+            ]
     except Exception as exc:
         print_error(f"Error encountered listing databases: {exc}")
 
     return databases
+
 
 def connect_gather_db():
     try:
@@ -182,12 +213,15 @@ def connect_gather_db():
         return {}
     return pg_version, databases_list, connection_params
 
+
 if __name__ == "__main__":
     pg_version, databases_list, connection_params = connect_gather_db()
     # Iterate through the list of database names, run checks, and create schemas
     for db_name in databases_list:
-        print_success(f"Discovered database: {db_name}\nCreating schema and checking permissions + stats")
-        connection_params['dbname'] = db_name
+        print_success(
+            f"Discovered database: {db_name}\nCreating schema and checking permissions + stats"
+        )
+        connection_params["dbname"] = db_name
         conn = psycopg2.connect(**connection_params)
         create_datadog_user_and_schema(conn, db_name, pg_version)
         explain_statement(conn, pg_version)
@@ -195,5 +229,7 @@ if __name__ == "__main__":
 
 
 print("Setup complete!")
-print_success("The databse monitoring setup completed sucessfully on the following databses:")
+print_success(
+    "The databse monitoring setup completed sucessfully on the following databses:"
+)
 print(f"\n {successful_setup}")

--- a/docker_stuff/eh_requirements.txt
+++ b/docker_stuff/eh_requirements.txt
@@ -8,4 +8,5 @@ uvicorn==0.23.2
 asyncio==3.4.3
 datadog==0.47.0
 python-dotenv
+secp256k1==0.14.0
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -56,7 +56,8 @@ class Event:
 
     async def parse_kind5(self, logger) -> None:
         event_values = []
-        extracted_events = [[key, value] for key, value in self.tags]
+        extracted_events = [key for key in self.tags]
+        logger.info(f"ex events is {extracted_events} of type {type(extracted_events)}")
         for array in extracted_events:
             logger.info(f"Array is {array}")
             if array[0].startswith(("#e", "#a")):

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -138,6 +138,7 @@ class Subscription:
     async def sanitize_event_keys(self, filters, logger) -> Dict:
         updated_keys = {}
         limit = ""
+        global_search = {}
         try:
             try:
                 limit = filters.get("limit", 100)

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -73,8 +73,6 @@ class Event:
         await conn.commit()
 
     def parse_kind5(self, statsd) -> List:
-        #extracted_events = [key for key in self.tags]
-        #event_values = [array[1] for array in extracted_events]
         event_values = [array[1] for array in self.tags]
         statsd.decrement("nostr.event.added.count", tags=["func:new_event"])
         statsd.increment("nostr.event.deleted.count", tags=["func:new_event"])

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -75,8 +75,8 @@ class Event:
         for array in extracted_events:
             logger.info(f"Array is {array} and of type {type(array)}")
             logger.info(f"Array 0 is {array[0]}")
-            if array[0].startswith(("#e", "#a")):
-                event_values.append(array[1])
+
+            event_values.append(array[1])
         logger.info(f"Returning ev : {event_values}")
         return event_values
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -56,7 +56,7 @@ class Event:
 
     async def parse_kind5(self, logger) -> None:
         event_values = []
-        extracted_events = [[event] for event in self.tags]
+        extracted_events = [[key, value] for key, value in self.tags]
         for array in extracted_events:
             logger.info(f"Array is {array}")
             if array[0].startswith(("#e", "#a")):

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -164,13 +164,13 @@ class Subscription:
         return complete_cluase
     
     def _search_tags(self, search_item):
-            search_clause = (
-                " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
-            )
-            conditions = [f"elem::text LIKE '%{search_item}%'"]
-    
-            complete_clause = search_clause.format(" OR ".join(conditions))
-            return complete_clause
+        search_clause = (
+            " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
+        )
+        conditions = [f"elem::text LIKE '%{search_item}%'"]
+
+        complete_clause = search_clause.format(" OR ".join(conditions))
+        return complete_clause
     
     def _search_content(self, search_item):
         search_clause = (

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -80,16 +80,14 @@ class Event:
         return event_values
 
     async def delete_event(self, conn, cur, delete_events, logger) -> bool:
-        logger.info(f" delete_events var is {delete_events}")
+        logger.info(f"delete_events var is {delete_events}")
         delete_statement = """
         DELETE FROM events
-        WHERE id = {};
+        WHERE id = ANY(%s) AND pubkey = %s;
         """
-        conditions = [f"'{event_id}'" for event_id in delete_events]
-        logger.info(f"conditions is {conditions}")
-        complete_clause = delete_statement.format(" OR ".join(conditions))
-        logger.info(f"complete cluase is {complete_clause}")
-        await cur.execute(complete_clause)
+        event_ids = [event_id for event_id in delete_events]
+        logger.info(f"event_ids is {event_ids}")
+        await cur.execute(delete_statement, (event_ids, self.pubkey))
         await conn.commit()
 
         

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -73,7 +73,8 @@ class Event:
         extracted_events = [key for key in self.tags]
         logger.info(f"ex events is {extracted_events} of type {type(extracted_events)}")
         for array in extracted_events:
-            logger.info(f"Array is {array}")
+            logger.info(f"Array is {array} and of type {type(array)}")
+            logger.info(f"Array 0 is {array[0]}")
             if array[0].startswith(("#e", "#a")):
                 event_values.append(array[1])
         logger.info(f"Returning ev : {event_values}")

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -242,15 +242,15 @@ class Subscription:
             return None
 
     async def parse_filters(self, filters: dict, logger) -> tuple:
-        updated_keys, limit = await self.sanitize_event_keys(filters, logger)
+        updated_keys, limit, global_search = await self.sanitize_event_keys(filters, logger)
         logger.debug(f"Updated keys is: {updated_keys}")
         if updated_keys:
             tag_values, query_parts = await self.parse_sanitized_keys(
                 updated_keys, logger
             )
-            return tag_values, query_parts, limit
+            return tag_values, query_parts, limit, global_search
         else:
-            return {}, {}, None
+            return {}, {}, None, {}
 
     def base_query_builder(self, tag_values, query_parts, limit, search_clause, logger):
         try:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -126,7 +126,7 @@ class Subscription:
         complete_cluase = tag_clause.format(" OR ".join(conditions))
         return complete_cluase
     
-    def _generate_search_clause(self, search_item):
+    def _search_tags(self, search_item):
             search_clause = (
                 " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
             )
@@ -272,10 +272,10 @@ class Subscription:
                 self.where_clause += f" AND {tag_clause}"
 
             if global_search:
-                search_clause = self._generate_search_clause(global_search)
+                search_clause = self._search_tags(global_search)
                 search_content = self._search_content(global_search)
-                self.where_clause += f" AND {search_content}"
-                self.where_clause += f" OR {search_clause}"
+                self.where_clause += f" AND ({search_content} OR {search_clause})"
+
                 
 
             if not limit:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -54,12 +54,13 @@ class Event:
         statsd.increment("nostr.event.deleted.count", tags=["func:new_event"])
         await conn.commit()
 
-    async def parse_kind5(self) -> None:
+    async def parse_kind5(self, logger) -> None:
         event_values = []
         extracted_events = [event for event in self.tags]
         for array in extracted_events:
             if array[0].startswith(("#e", "#a")):
                 event_values.append(array[1])
+        logger.info(f"Returning ev : {event_values}")
         return event_values
 
     async def delete_event(self, conn, cur, delete_events) -> bool:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -69,14 +69,7 @@ class Event:
         await conn.commit()
 
     async def parse_kind5(self, logger) -> None:
-        event_values = []
-        extracted_events = [key for key in self.tags]
-        logger.info(f"ex events is {extracted_events} of type {type(extracted_events)}")
-        for array in extracted_events:
-            logger.info(f"Array is {array} and of type {type(array)}")
-            logger.info(f"Array 0 is {array[0]}")
-
-            event_values.append(array[1])
+        event_values = [self.tags[key][1] for key in self.tags]
         logger.info(f"Returning ev : {event_values}")
         return event_values
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -144,7 +144,7 @@ class Subscription:
         return complete_cluase
 
 
-    async def sanitize_event_keys(self, filters, logger) -> Dict:
+    async def _sanitize_event_keys(self, filters, logger) -> Dict:
         updated_keys = {}
         limit = ""
         global_search = {}
@@ -181,7 +181,7 @@ class Subscription:
             logger.error(f"An unexpected error occurred: {e}", exc_info=True)
             return updated_keys, limit, global_search
 
-    async def parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
+    async def _parse_sanitized_keys(self, updated_keys, logger) -> Tuple[List, List]:
         query_parts = []
         tag_values = []
 
@@ -252,10 +252,10 @@ class Subscription:
             return None
 
     async def parse_filters(self, filters: dict, logger) -> tuple:
-        updated_keys, limit, global_search = await self.sanitize_event_keys(filters, logger)
+        updated_keys, limit, global_search = await self._sanitize_event_keys(filters, logger)
         logger.debug(f"Updated keys is: {updated_keys}")
         if updated_keys:
-            tag_values, query_parts = await self.parse_sanitized_keys(
+            tag_values, query_parts = await self._parse_sanitized_keys(
                 updated_keys, logger
             )
             return tag_values, query_parts, limit, global_search
@@ -275,7 +275,7 @@ class Subscription:
                 search_clause = self._generate_search_clause(global_search)
                 search_content = self._search_content(global_search)
                 self.where_clause += f" AND {search_clause}"
-                self.where_clause += f" AND {search_content}"
+                self.where_clause += f" OR {search_content}"
 
             if not limit:
                 limit = 100

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -129,7 +129,7 @@ class Subscription:
         search_clause = (
             " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
-        conditions = [f"elem::text LIKE '%{search_item}%"]
+        conditions = [f"elem::text LIKE '%{search_item}%'"]
 
         complete_cluase = search_clause.format(" OR ".join(conditions))
         return complete_cluase

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -127,13 +127,16 @@ class Subscription:
         return complete_cluase
     
     def generate_search_clause(self, search_item):
-        search_clause = (
-            " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
-        )
-        conditions = [f"elem::text LIKE '%{search_item}%'"]
-
-        complete_cluase = search_clause.format(" OR ".join(conditions))
-        return complete_cluase
+        if search_item:
+            search_clause = (
+                " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
+            )
+            conditions = [f"elem::text LIKE '%{search_item}%'"]
+    
+            complete_cluase = search_clause.format(" OR ".join(conditions))
+            return complete_cluase
+        else: 
+            return None
 
 
     async def sanitize_event_keys(self, filters, logger) -> Dict:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -58,6 +58,7 @@ class Event:
         event_values = []
         extracted_events = [event for event in self.tags]
         for array in extracted_events:
+            logger.info(f"Array is {array}")
             if array[0].startswith(("#e", "#a")):
                 event_values.append(array[1])
         logger.info(f"Returning ev : {event_values}")

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -127,7 +127,6 @@ class Subscription:
         return complete_cluase
     
     def generate_search_clause(self, search_item):
-        if search_item:
             search_clause = (
                 " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
             )
@@ -135,8 +134,7 @@ class Subscription:
     
             complete_cluase = search_clause.format(" OR ".join(conditions))
             return complete_cluase
-        else: 
-            return None
+
 
 
     async def sanitize_event_keys(self, filters, logger) -> Dict:
@@ -257,7 +255,7 @@ class Subscription:
         else:
             return {}, {}, None, {}
 
-    def base_query_builder(self, tag_values, query_parts, limit, search_clause, logger):
+    def base_query_builder(self, tag_values, query_parts, limit, global_search, logger):
         try:
             if query_parts:
                 self.where_clause = " AND ".join(query_parts)
@@ -266,7 +264,8 @@ class Subscription:
                 tag_clause = self.generate_tag_clause(tag_values)
                 self.where_clause += f" AND {tag_clause}"
 
-            if search_clause:
+            if global_search:
+                search_clause = self.generate_search_clause(global_search)
                 self.where_clause += f" AND {search_clause}"
 
             if not limit:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -117,7 +117,7 @@ class Subscription:
             "sig",
         ]
 
-    def generate_tag_clause(self, tags) -> str:
+    def _generate_tag_clause(self, tags) -> str:
         tag_clause = (
             " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
@@ -126,7 +126,7 @@ class Subscription:
         complete_cluase = tag_clause.format(" OR ".join(conditions))
         return complete_cluase
     
-    def generate_search_clause(self, search_item):
+    def _generate_search_clause(self, search_item):
             search_clause = (
                 " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
             )
@@ -134,7 +134,14 @@ class Subscription:
     
             complete_cluase = search_clause.format(" OR ".join(conditions))
             return complete_cluase
-
+    
+    def _search_content(self, search_item):
+        search_clause = (
+            f"content "
+        )
+        conditions = [f"LIKE '%{search_item}%'"]
+        complete_cluase = search_clause.format(" OR ".join(conditions))
+        return complete_cluase
 
 
     async def sanitize_event_keys(self, filters, logger) -> Dict:
@@ -261,12 +268,14 @@ class Subscription:
                 self.where_clause = " AND ".join(query_parts)
 
             if tag_values:
-                tag_clause = self.generate_tag_clause(tag_values)
+                tag_clause = self._generate_tag_clause(tag_values)
                 self.where_clause += f" AND {tag_clause}"
 
             if global_search:
-                search_clause = self.generate_search_clause(global_search)
+                search_clause = self._generate_search_clause(global_search)
+                search_content = self._search_content(global_search)
                 self.where_clause += f" AND {search_clause}"
+                self.where_clause += f"AND {search_content}"
 
             if not limit:
                 limit = 100

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -121,7 +121,7 @@ class Subscription:
         tag_clause = (
             " EXISTS ( SELECT 1 FROM jsonb_array_elements(tags) as elem WHERE {})"
         )
-        conditions = [f"elem @> '{json.dumps(tag_pair)}'" for tag_pair in tags]
+        conditions = [f"elem @> '{tag_pair}'" for tag_pair in tags]
 
         complete_cluase = tag_clause.format(" OR ".join(conditions))
         return complete_cluase
@@ -274,8 +274,9 @@ class Subscription:
             if global_search:
                 search_clause = self._generate_search_clause(global_search)
                 search_content = self._search_content(global_search)
-                self.where_clause += f" AND {search_clause}"
-                self.where_clause += f" OR {search_content}"
+                self.where_clause += f" AND {search_content}"
+                self.where_clause += f" OR {search_clause}"
+                
 
             if not limit:
                 limit = 100

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -106,6 +106,7 @@ class Subscription:
     def __init__(self, request_payload: dict) -> None:
         self.filters = request_payload.get("event_dict", {})
         self.subscription_id = request_payload.get("subscription_id")
+        self.where_clause = ""
         self.column_names = [
             "id",
             "pubkey",

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -56,7 +56,7 @@ class Event:
 
     async def parse_kind5(self, logger) -> None:
         event_values = []
-        extracted_events = [event for event in self.tags]
+        extracted_events = [[event] for event in self.tags]
         for array in extracted_events:
             logger.info(f"Array is {array}")
             if array[0].startswith(("#e", "#a")):

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -45,7 +45,7 @@ class Event:
     def __str__(self) -> str:
         return f"{self.event_id}, {self.pubkey}, {self.kind}, {self.created_at}, {self.tags}, {self.content}, {self.sig} "
 
-    async def verify_signature(self, logger) -> bool:
+    def verify_signature(self, logger) -> bool:
         try:
             pub_key: secp256k1.PublicKey = secp256k1.PublicKey(bytes.fromhex("02" + self.pubkey), True)
             result: bool = pub_key.schnorr_verify(bytes.fromhex(self.event_id), bytes.fromhex(self.sig), None, raw=True)
@@ -68,7 +68,7 @@ class Event:
         statsd.increment("nostr.event.deleted.count", tags=["func:new_event"])
         await conn.commit()
 
-    async def parse_kind5(self, logger) -> None:
+    def parse_kind5(self, logger) -> None:
         event_values = [self.tags[key][1] for key in self.tags]
         logger.info(f"Returning ev : {event_values}")
         return event_values

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -54,7 +54,7 @@ class Event:
         statsd.increment("nostr.event.deleted.count", tags=["func:new_event"])
         await conn.commit()
 
-    async def parse_kind5(self, deletion_event):
+    async def parse_kind5(self) -> None:
         event_values = []
         extracted_events = [event for event in self.tags]
         for array in extracted_events:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -276,12 +276,10 @@ class Subscription:
                 search_content = self._search_content(global_search)
                 self.where_clause += f" AND ({search_content} OR {search_clause})"
 
-                
-
             if not limit:
                 limit = 100
 
-            self.base_query = f"SELECT * FROM events WHERE {self.where_clause} ORDER BY created_at LIMIT {limit} ;"
+            self.base_query = f"SELECT * FROM events WHERE {self.where_clause} ORDER BY created_at DESC LIMIT {limit} ;"
             logger.debug(f"SQL query constructed: {self.base_query}")
             return self.base_query
         except Exception as exc:

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -71,7 +71,7 @@ class Event:
         DELETE FROM events
         WHERE id = {};
         """
-        conditions = [f"{event_id}" for event_id in delete_events]
+        conditions = [f"'{event_id}'" for event_id in delete_events]
         logger.info(f"conditions is {conditions}")
         complete_clause = delete_statement.format(" OR ".join(conditions))
         logger.info(f"complete cluase is {complete_clause}")

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -65,13 +65,16 @@ class Event:
         logger.info(f"Returning ev : {event_values}")
         return event_values
 
-    async def delete_event(self, conn, cur, delete_events) -> bool:
+    async def delete_event(self, conn, cur, delete_events, logger) -> bool:
+        logger.info(f" delete_events var is {delete_events}")
         delete_statement = """
         DELETE FROM events
-        WHERE id = {}
+        WHERE id = {};
         """
         conditions = [f"{event_id}" for event_id in delete_events]
+        logger.info(f"conditions is {conditions}")
         complete_clause = delete_statement.format(" OR ".join(conditions))
+        logger.info(f"complete cluase is {complete_clause}")
         await cur.execute(complete_clause)
         await conn.commit()
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -137,7 +137,7 @@ class Subscription:
     
     def _search_content(self, search_item):
         search_clause = (
-            f"content "
+            "content {}"
         )
         conditions = [f"LIKE '%{search_item}%'"]
         complete_cluase = search_clause.format(" OR ".join(conditions))
@@ -275,7 +275,7 @@ class Subscription:
                 search_clause = self._generate_search_clause(global_search)
                 search_content = self._search_content(global_search)
                 self.where_clause += f" AND {search_clause}"
-                self.where_clause += f"AND {search_content}"
+                self.where_clause += f" AND {search_content}"
 
             if not limit:
                 limit = 100

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -69,7 +69,8 @@ class Event:
         await conn.commit()
 
     def parse_kind5(self, logger) -> None:
-        event_values = [self.tags[key][1] for key in self.tags]
+        extracted_events = [key for key in self.tags]
+        event_values = [array[1] for array in extracted_events]
         logger.info(f"Returning ev : {event_values}")
         return event_values
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -118,6 +118,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 elif event_obj.kind == 5:
                     logger.info(f" event obj kind is {event_obj.kind}")
                     logger.info(f"ev tags is {event_obj.tags}")
+                    if event_obj.verify_signature(logger)
                     events_to_delete = await event_obj.parse_kind5(logger)
                     logger.info(f"ev to del is {events_to_delete}")
                     await event_obj.delete_event(conn, cur, events_to_delete, logger)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -120,7 +120,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
                     logger.info(f"ev tags is {event_obj.tags}")
                     events_to_delete = await event_obj.parse_kind5(logger)
                     logger.info(f"ev to del is {events_to_delete}")
-                    await event_obj.delete_event(conn, cur, events_to_delete)
+                    await event_obj.delete_event(conn, cur, events_to_delete, logger)
                 else:
                     await event_obj.add_event(conn, cur)
                     statsd.increment("nostr.event.added.count", tags=["func:new_event"])

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -118,10 +118,11 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 elif event_obj.kind == 5:
                     logger.info(f" event obj kind is {event_obj.kind}")
                     logger.info(f"ev tags is {event_obj.tags}")
-                    if event_obj.verify_signature(logger):
+                    if await event_obj.verify_signature(logger):
                         events_to_delete = await event_obj.parse_kind5(logger)
                         logger.info(f"ev to del is {events_to_delete}")
                         await event_obj.delete_event(conn, cur, events_to_delete, logger)
+                        return event_obj.evt_response("true", 200)
                     else:
                         return event_obj.evt_response("flase", 200)
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -29,7 +29,7 @@ tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 log_file = "./logs/event_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -12,7 +12,6 @@ from datadog import initialize, statsd
 from ddtrace import tracer
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 
 from event_classes import Event, Subscription
 from psycopg_pool import AsyncConnectionPool

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -122,6 +122,9 @@ async def handle_new_event(request: Request) -> JSONResponse:
                         events_to_delete = await event_obj.parse_kind5(logger)
                         logger.info(f"ev to del is {events_to_delete}")
                         await event_obj.delete_event(conn, cur, events_to_delete, logger)
+                    else:
+                        return event_obj.evt_response("flase", 200)
+
                 else:
                     await event_obj.add_event(conn, cur)
                     statsd.increment("nostr.event.added.count", tags=["func:new_event"])

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -116,7 +116,9 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 if event_obj.kind in [0, 3]:
                     await event_obj.delete_check(conn, cur, statsd)
                 elif event_obj.kind == 5:
+                    logger.info(f" event obj kind is {event_obj.kind}")
                     events_to_delete = await event_obj.parse_kind5(logger)
+                    logger.info(f"ev to del is {events_to_delete}")
                     await event_obj.delete_event(conn, cur, events_to_delete)
                 else:
                     await event_obj.add_event(conn, cur)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -117,6 +117,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
                     await event_obj.delete_check(conn, cur, statsd)
                 elif event_obj.kind == 5:
                     logger.info(f" event obj kind is {event_obj.kind}")
+                    logger.info(f"ev tags is {event_obj.tags}")
                     events_to_delete = await event_obj.parse_kind5(logger)
                     logger.info(f"ev to del is {events_to_delete}")
                     await event_obj.delete_event(conn, cur, events_to_delete)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -118,8 +118,8 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 elif event_obj.kind == 5:
                     logger.info(f" event obj kind is {event_obj.kind}")
                     logger.info(f"ev tags is {event_obj.tags}")
-                    if await event_obj.verify_signature(logger):
-                        events_to_delete = await event_obj.parse_kind5(logger)
+                    if event_obj.verify_signature(logger):
+                        events_to_delete = event_obj.parse_kind5(logger)
                         logger.info(f"ev to del is {events_to_delete}")
                         await event_obj.delete_event(conn, cur, events_to_delete, logger)
                         return event_obj.evt_response("true", 200)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -118,10 +118,10 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 elif event_obj.kind == 5:
                     logger.info(f" event obj kind is {event_obj.kind}")
                     logger.info(f"ev tags is {event_obj.tags}")
-                    if event_obj.verify_signature(logger)
-                    events_to_delete = await event_obj.parse_kind5(logger)
-                    logger.info(f"ev to del is {events_to_delete}")
-                    await event_obj.delete_event(conn, cur, events_to_delete, logger)
+                    if event_obj.verify_signature(logger):
+                        events_to_delete = await event_obj.parse_kind5(logger)
+                        logger.info(f"ev to del is {events_to_delete}")
+                        await event_obj.delete_event(conn, cur, events_to_delete, logger)
                 else:
                     await event_obj.add_event(conn, cur)
                     statsd.increment("nostr.event.added.count", tags=["func:new_event"])

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -12,6 +12,7 @@ from datadog import initialize, statsd
 from ddtrace import tracer
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from event_classes import Event, Subscription
 from psycopg_pool import AsyncConnectionPool

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -148,10 +148,8 @@ async def handle_subscription(request: Request) -> JSONResponse:
             subscription_obj.filters, logger
         )
 
-        search_clause = subscription_obj.generate_search_clause(global_search)
-
         sql_query = subscription_obj.base_query_builder(
-            tag_values, query_parts, limit, search_clause, logger
+            tag_values, query_parts, limit, global_search, logger
         )
 
         cached_results = subscription_obj.fetch_data_from_cache(

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -116,7 +116,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 if event_obj.kind in [0, 3]:
                     await event_obj.delete_check(conn, cur, statsd)
                 elif event_obj.kind == 5:
-                    events_to_delete = await event_obj.parse_kind5()
+                    events_to_delete = await event_obj.parse_kind5(logger)
                     await event_obj.delete_event(conn, cur, events_to_delete)
                 else:
                     await event_obj.add_event(conn, cur)

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -144,12 +144,14 @@ async def handle_subscription(request: Request) -> JSONResponse:
             )
 
         logger.debug(f"Fiters are: {subscription_obj.filters}")
-        tag_values, query_parts, limit = await subscription_obj.parse_filters(
+        tag_values, query_parts, limit, global_search = await subscription_obj.parse_filters(
             subscription_obj.filters, logger
         )
 
+        search_clause = subscription_obj.generate_search_clause(global_search)
+
         sql_query = subscription_obj.base_query_builder(
-            tag_values, query_parts, limit, logger
+            tag_values, query_parts, limit, search_clause, logger
         )
 
         cached_results = subscription_obj.fetch_data_from_cache(

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -29,7 +29,7 @@ tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 log_file = "./logs/event_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -451,7 +451,7 @@ async def send_subscription_to_handler(
 
 
 if __name__ == "__main__":
-    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=500)
+    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=5000)
 
     try:
         start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)


### PR DESCRIPTION
**Additions**
* #37 
  * Add support
  * Support for [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md#nip-50) search queries
  * Searches tags and content fields
  * Compatible with searching [NIP-99 Classified Listings](https://github.com/nostr-protocol/nips/blob/master/99.md)
* #38 
  * Add support for NIP-09 event deletions
  * Upon receiving a request from a client, relay will:
    * Check if event is `kind 5`
      * Validate the `sig` of the event
      * Delete events where `pubkey` = `pubkey` from `kind 5` event (can only delete your own events)
      * Respond to client with `["OK","true]` response

**Bug Fixes**
* Fixed #39
* Fixed #40 
  * Default `limit` is now 100