### PR TITLE
Fix OK responses for events

### DIFF
--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -104,7 +104,7 @@ class Event:
         )
         await conn.commit()
 
-    def evt_response(self, results_status, http_status_code, message=None):
+    def evt_response(self, results_status, http_status_code, message=""):
         response = {
             "event": "OK",
             "subscription_id": self.event_id,

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -104,7 +104,7 @@ class Event:
         )
         await conn.commit()
 
-    def evt_response(self, results_status, http_status_code, message=""):
+    def evt_response(self, results_status, http_status_code, message=None):
         response = {
             "event": "OK",
             "subscription_id": self.event_id,

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -104,11 +104,12 @@ class Event:
         )
         await conn.commit()
 
-    def evt_response(self, results_json, http_status_code):
+    def evt_response(self, results_status, http_status_code, message=""):
         response = {
             "event": "OK",
-            "event_id": "n0stafarian419",
-            "results_json": results_json,
+            "subscription_id": self.event_id,
+            "results_json": results_status,
+            "message": message
         }
         return JSONResponse(content=response, status_code=http_status_code)
 

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -107,7 +107,7 @@ class Event:
     def evt_response(self, results_json, http_status_code):
         response = {
             "event": "OK",
-            "subscription_id": "n0stafarian419",
+            "event_id": "n0stafarian419",
             "results_json": results_json,
         }
         return JSONResponse(content=response, status_code=http_status_code)

--- a/docker_stuff/python_stuff/event_classes.py
+++ b/docker_stuff/python_stuff/event_classes.py
@@ -109,7 +109,7 @@ class Event:
             "event": "OK",
             "subscription_id": self.event_id,
             "results_json": results_status,
-            "message": message
+            "message": message,
         }
         return JSONResponse(content=response, status_code=http_status_code)
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -133,14 +133,18 @@ async def handle_new_event(request: Request) -> JSONResponse:
     except psycopg.IntegrityError as e:
         conn.rollback()
         logger.info(f"Event with ID {event_obj.event_id} already exists")
-        return event_obj.evt_response(
+        resp = event_obj.evt_response(
             results_status="true", http_status_code=409, message="duplicate: already have this event"
         )
+        logger.debug(f"resp integ error is {resp}")
+        return resp
     except Exception as e:
         conn.rollback()
-        return event_obj.evt_response(
+        resp = event_obj.evt_response(
             results_status="false", http_status_code=500, message="error: could not connect to the database"
         )
+        logger.debug(f"resp gen error is {resp}")
+        return resp
 
 
 @app.post("/subscription")

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -121,25 +121,25 @@ async def handle_new_event(request: Request) -> JSONResponse:
                         await event_obj.delete_event(
                             conn, cur, events_to_delete, logger
                         )
-                        return event_obj.evt_response("true", 200)
+                        return event_obj.evt_response(results_status="true", http_status_code=200)
                     else:
-                        return event_obj.evt_response("flase", 200)
+                        return event_obj.evt_response(results_status="flase", http_status_code=200)
 
                 else:
                     await event_obj.add_event(conn, cur)
                     statsd.increment("nostr.event.added.count", tags=["func:new_event"])
-                return event_obj.evt_response("true", 200)
+                return event_obj.evt_response(results_status="true", http_status_code=200)
 
     except psycopg.IntegrityError as e:
         conn.rollback()
         logger.info(f"Event with ID {event_obj.event_id} already exists")
         return event_obj.evt_response(
-            "true", 409, "duplicate: already have this event"
+            results_status="true", http_status_code=409, message="duplicate: already have this event"
         )
     except Exception as e:
         conn.rollback()
         return event_obj.evt_response(
-            "false", 500, "error: could not connect to the database"
+            results_status="false", http_status_code=500, message="error: could not connect to the database"
         )
 
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -131,6 +131,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
                 return event_obj.evt_response(results_status="true", http_status_code=200)
 
     except psycopg.IntegrityError as e:
+        logger.debug(f"Entering integ loop")
         conn.rollback()
         logger.info(f"Event with ID {event_obj.event_id} already exists")
         resp = event_obj.evt_response(
@@ -139,6 +140,7 @@ async def handle_new_event(request: Request) -> JSONResponse:
         logger.debug(f"resp integ error is {resp}")
         return resp
     except Exception as e:
+        logger.debug(f"Entering gen exc")
         conn.rollback()
         resp = event_obj.evt_response(
             results_status="false", http_status_code=500, message="error: could not connect to the database"

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -130,33 +130,21 @@ async def handle_new_event(request: Request) -> JSONResponse:
                         await event_obj.add_event(conn, cur)
                         statsd.increment("nostr.event.added.count", tags=["func:new_event"])
                     except psycopg.IntegrityError as e:
-                        logger.debug(f"Entering integ loop")
                         conn.rollback()
                         logger.info(f"Event with ID {event_obj.event_id} already exists")
-                        resp = event_obj.evt_response(
+                        return event_obj.evt_response(
                             results_status="true", http_status_code=409, message="duplicate: already have this event"
                         )
-                        logger.debug(f"resp integ error is {resp}")
-                        return resp
+
                 return event_obj.evt_response(results_status="true", http_status_code=200)
 
-    except psycopg.IntegrityError as e:
-        logger.debug(f"Entering integ loop")
-        conn.rollback()
-        logger.info(f"Event with ID {event_obj.event_id} already exists")
-        resp = event_obj.evt_response(
-            results_status="true", http_status_code=409, message="duplicate: already have this event"
-        )
-        logger.debug(f"resp integ error is {resp}")
-        return resp
     except Exception as e:
         logger.debug(f"Entering gen exc")
         conn.rollback()
-        resp = event_obj.evt_response(
+        return event_obj.evt_response(
             results_status="false", http_status_code=500, message="error: could not connect to the database"
         )
-        logger.debug(f"resp gen error is {resp}")
-        return resp
+
 
 
 @app.post("/subscription")

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -121,30 +121,43 @@ async def handle_new_event(request: Request) -> JSONResponse:
                         await event_obj.delete_event(
                             conn, cur, events_to_delete, logger
                         )
-                        return event_obj.evt_response(results_status="true", http_status_code=200)
+                        return event_obj.evt_response(
+                            results_status="true", http_status_code=200
+                        )
                     else:
-                        return event_obj.evt_response(results_status="flase", http_status_code=200)
+                        return event_obj.evt_response(
+                            results_status="flase", http_status_code=200
+                        )
 
                 else:
                     try:
                         await event_obj.add_event(conn, cur)
-                        statsd.increment("nostr.event.added.count", tags=["func:new_event"])
+                        statsd.increment(
+                            "nostr.event.added.count", tags=["func:new_event"]
+                        )
                     except psycopg.IntegrityError as e:
                         conn.rollback()
-                        logger.info(f"Event with ID {event_obj.event_id} already exists")
+                        logger.info(
+                            f"Event with ID {event_obj.event_id} already exists"
+                        )
                         return event_obj.evt_response(
-                            results_status="true", http_status_code=409, message="duplicate: already have this event"
+                            results_status="true",
+                            http_status_code=409,
+                            message="duplicate: already have this event",
                         )
 
-                return event_obj.evt_response(results_status="true", http_status_code=200)
+                return event_obj.evt_response(
+                    results_status="true", http_status_code=200
+                )
 
     except Exception as e:
         logger.debug(f"Entering gen exc")
         conn.rollback()
         return event_obj.evt_response(
-            results_status="false", http_status_code=500, message="error: could not connect to the database"
+            results_status="false",
+            http_status_code=500,
+            message="error: could not connect to the database",
         )
-
 
 
 @app.post("/subscription")

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -132,13 +132,14 @@ async def handle_new_event(request: Request) -> JSONResponse:
 
     except psycopg.IntegrityError as e:
         conn.rollback()
+        logger.info(f"Event with ID {event_obj.event_id} already exists")
         return event_obj.evt_response(
-            f"Event with ID {event_obj.event_id} already exists", 409
+            "true", 409, "duplicate: already have this event"
         )
     except Exception as e:
         conn.rollback()
         return event_obj.evt_response(
-            f"Error:{e} occured adding event {event_obj.event_id}", 409
+            "false", 500, "error: could not connect to the database"
         )
 
 

--- a/docker_stuff/python_stuff/event_handler.py
+++ b/docker_stuff/python_stuff/event_handler.py
@@ -29,7 +29,7 @@ tracer.configure(hostname="172.28.0.5", port=8126)
 redis_client: redis.Redis = redis.Redis(host="172.28.0.6", port=6379)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 log_file = "./logs/event_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -168,8 +168,9 @@ class ExtractedResponse:
                 f"Error decoding JSON message in Extracted Response: {json_error}."
             )
             self.results = ""
-
-        self.message = response_data.get("message", "")
+            
+        if self.event_type == "EVENT":
+            self.message = response_data.get("message", "")
 
 
         self.comment = ""

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -168,8 +168,8 @@ class ExtractedResponse:
                 f"Error decoding JSON message in Extracted Response: {json_error}."
             )
             self.results = ""
-            
-        if self.event_type == "EVENT":
+
+        if self.event_type == "OK":
             self.message = response_data.get("message", "")
 
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -165,9 +165,9 @@ class ExtractedResponse:
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
-            logger.error(
-                f"Error decoding JSON message in Extracted Response: {json_error}."
-            )
+            #logger.error(
+            #    f"Error decoding JSON message in Extracted Response: {json_error}."
+            #)
             self.results = ""
 
         if self.event_type == "OK":

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -160,7 +160,7 @@ class ExtractedResponse:
 
         """
         self.event_type = response_data["event"]
-        self.subscription_id = response_data["event_id"]
+        self.subscription_id = response_data["subscription_id"]
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -172,6 +172,7 @@ class ExtractedResponse:
 
         if self.event_type == "OK":
             self.message = response_data.get("message", "")
+            logger.info(f"Response data: message extracted is {self.message}")
 
 
         self.comment = ""
@@ -413,6 +414,7 @@ async def send_event_to_handler(
                 )
                 await websocket.send(json.dumps(formatted_response))
             elif response.status != 200:
+                await websocket.send(json.dumps(await response_object.format_response()))
                 return response_object.event_response
     except Exception as e:
         logger.error(f"An error occurred while sending the event to the handler: {e}")
@@ -462,7 +464,7 @@ async def send_subscription_to_handler(
 
 
 if __name__ == "__main__":
-    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=5000)
+    rate_limiter = TokenBucketRateLimiter(tokens_per_second=1, max_tokens=50000)
 
     try:
         start_server = websockets.serve(handle_websocket_connection, "0.0.0.0", 8008)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -407,13 +407,7 @@ async def send_event_to_handler(
                 f"Received response from Event Handler {response_data}, data types is {type(response_data)}"
             )
             response_object = ExtractedResponse(response_data)
-            if response.status == 200:
-                formatted_response = await response_object.format_response()
-                logger.debug(
-                    f"Formatted response data from send_event_to_handler function: {formatted_response}"
-                )
-                await websocket.send(json.dumps(formatted_response))
-            elif response.status != 200:
+            if response.status:
                 formatted_response = await response_object.format_response()
                 await websocket.send(json.dumps(formatted_response))
     except Exception as e:

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -24,7 +24,7 @@ initialize(**options)
 tracer.configure(hostname="172.28.0.5", port=8126)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 log_file: str = "./logs/websocket_handler.log"
 handler = RotatingFileHandler(log_file, maxBytes=1000000, backupCount=5)

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -169,10 +169,8 @@ class ExtractedResponse:
             )
             self.results = ""
 
-        try:
-            self.message = response_data["message"]
-        except:
-            self.message = ""
+        self.message = response_data.get("message", "")
+
 
         self.comment = ""
         self.event_response: Tuple[str, Optional[str], str, Optional[str]]  = (

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -226,7 +226,7 @@ class ExtractedResponse:
                 self.event_type,
                 self.subscription_id,
                 self.results,
-                self.comment,
+                self.message,
             )
 
         else:

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -414,8 +414,8 @@ async def send_event_to_handler(
                 )
                 await websocket.send(json.dumps(formatted_response))
             elif response.status != 200:
-                await websocket.send(json.dumps(await response_object.format_response()))
-                return response_object.event_response
+                formatted_response = await response_object.format_response()
+                await websocket.send(json.dumps(formatted_response))
     except Exception as e:
         logger.error(f"An error occurred while sending the event to the handler: {e}")
 

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -161,41 +161,15 @@ class ExtractedResponse:
         """
         self.event_type = response_data["event"]
         self.subscription_id = response_data["subscription_id"]
-        self.message = ""
+        self.message = response_data.get("message", "")
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
-            #logger.error(
-            #    f"Error decoding JSON message in Extracted Response: {json_error}."
-            #)
+            logger.error(
+                f"Error decoding JSON message in Extracted Response: {json_error}."
+            )
             self.results = ""
 
-        if self.event_type == "OK":
-            self.message = response_data.get("message", "")
-            logger.info(f"Response data: message extracted is {self.message}")
-
-
-        self.comment = ""
-        self.event_response: Tuple[str, Optional[str], str, Optional[str]]  = (
-            self.event_type,
-            self.subscription_id,
-            self.results,
-            self.message
-        )
-        self.rate_limit_response: Tuple[str, Optional[str], str, Optional[str]] = (
-            "OK",
-            "nostafarian419",
-            "false",
-            "rate-limited: slow your roll nostrich",
-        )
-        self.duplicate_response: Tuple[str, Optional[str], str, Optional[str]] = (
-            "OK",
-            "nostafarian419",
-            "false",
-            "duplicate: already have this event",
-        )
-
-    #
     async def _process_event(self, event_result):
         try:
             logger.debug(f"event_result var is {event_result}")
@@ -204,7 +178,6 @@ class ExtractedResponse:
         except Exception as exc:
             logger.error(f"Process events exc is {exc}", exc_info=True)
             return ""
-        #
 
     async def format_response(self):
         """

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -161,6 +161,7 @@ class ExtractedResponse:
         """
         self.event_type = response_data["event"]
         self.subscription_id = response_data["subscription_id"]
+        self.message = ""
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
@@ -178,7 +179,7 @@ class ExtractedResponse:
             self.event_type,
             self.subscription_id,
             self.results,
-            response_data["message"]
+            self.message
         )
         self.rate_limit_response: Tuple[str, Optional[str], str, Optional[str]] = (
             "OK",

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -169,6 +169,11 @@ class ExtractedResponse:
             )
             self.results = ""
 
+        try:
+            self.message = response_data["message"]
+        except:
+            self.message = ""
+
         self.comment = ""
         self.event_response: Tuple[str, Optional[str], str, Optional[str]]  = (
             self.event_type,

--- a/docker_stuff/python_stuff/websocket_handler.py
+++ b/docker_stuff/python_stuff/websocket_handler.py
@@ -160,7 +160,7 @@ class ExtractedResponse:
 
         """
         self.event_type = response_data["event"]
-        self.subscription_id = response_data["subscription_id"]
+        self.subscription_id = response_data["event_id"]
         try:
             self.results = json.loads(response_data["results_json"])
         except json.JSONDecodeError as json_error:
@@ -170,6 +170,12 @@ class ExtractedResponse:
             self.results = ""
 
         self.comment = ""
+        self.event_response: Tuple[str, Optional[str], str, Optional[str]]  = (
+            self.event_type,
+            self.subscription_id,
+            self.results,
+            response_data["message"]
+        )
         self.rate_limit_response: Tuple[str, Optional[str], str, Optional[str]] = (
             "OK",
             "nostafarian419",
@@ -401,8 +407,8 @@ async def send_event_to_handler(
                     f"Formatted response data from send_event_to_handler function: {formatted_response}"
                 )
                 await websocket.send(json.dumps(formatted_response))
-            elif response.status == 409:
-                return response_object.duplicate_response
+            elif response.status != 200:
+                return response_object.event_response
     except Exception as e:
         logger.error(f"An error occurred while sending the event to the handler: {e}")
 


### PR DESCRIPTION
## Summary
This fixes #47 and #48, relay is now returning `OK` messages using the correct syntax. Also removed unnecessary lines of code to modify and reuse functionality from `ExtractedResponse` class