### PR TITLE
Fix incorrect matching of new events from pubsub channel

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt
       - /var/lib/letsencrypt:/var/lib/letsencrypt
     depends_on:
-      - websocket_handler
+      - websocket-handler
     logging:
       driver: "json-file"
       options:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
       - ./postgresql.conf:/postgresql.conf
       - ./postgresql/data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PGUSER_WRITE}"]
+      test: [ "CMD-SHELL", "pg_isready -U ${PGUSER_WRITE}" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -85,8 +85,6 @@ services:
 
   redis:
     image: redis:latest
-    ports:
-      - "6379:6379"
     networks:
       nostpy_network:
         ipv4_address: 172.28.0.6
@@ -139,9 +137,9 @@ services:
     ports:
       - "55680:55680"
       - "4317:4317"
-    command: ["--config=/etc/otel/config.yaml"]
+    command: [ "--config=/etc/otel/config.yaml" ]
     group_add:
-      - "999"  # Add to docker group to access docker socket
+      - "999" # Add to docker group to access docker socket
     logging:
       driver: "json-file"
       options:
@@ -150,6 +148,7 @@ services:
 
 volumes:
   postgres_data:
+
 
 networks:
   nostpy_network:

--- a/docker/nostpy_relay/websocket_classes.py
+++ b/docker/nostpy_relay/websocket_classes.py
@@ -168,6 +168,9 @@ class SubscriptionMatcher:
         """
         for list_item in self.filters:
             for filter_, value in list_item.items():
+                if filter == 'limit':
+                    self.logger.debug('Ignoring limit filter')
+                    continue
                 self.logger.debug(f"Checking filter: {filter_}, value : {value}")
                 combined = {filter_: value}
                 if self._match_single_filter(combined, event):
@@ -217,9 +220,6 @@ class SubscriptionMatcher:
                         f"Filter mismatch for tag '{key}': {event.get('tags', [])}"
                     )
                     return False
-            elif key == "limit":
-                self.logger.debug(f"Limit key = {value}")
-                continue
             elif key == "since":
                 if event.get("created_at", 0) < value:
                     return False

--- a/docker/nostpy_relay/websocket_classes.py
+++ b/docker/nostpy_relay/websocket_classes.py
@@ -172,11 +172,12 @@ class SubscriptionMatcher:
                 combined = {filter_: value}
                 if self._match_single_filter(combined, event):
                     self.logger.debug(f"Event matches filter: {filter_}")
+                    return True
                 else:
                     self.logger.debug("filter did not match the event.")
-                    return False
-            self.logger.debug("Returning true")
-            return True
+
+            self.logger.debug("Returning false")
+            return False
 
     def _match_single_filter(
         self, filter_: Dict[str, Any], event: Dict[str, Any]


### PR DESCRIPTION
I was working with direct messages in our Nostr client and I found out that new messages are not being received and I had to send a new request to fetch them.

This is the request similar to what client is sending:

```json
[
    "REQ",
    "uniquestring",
    {
        "kinds": [
            1985
        ],
        "#p": [
            "1e6b46219a6638e42cabdbd9c2d9094c447ce46483f9dd202c958b8a525dbb93"
        ],
        "since": 1745275800
    },
    {
        "authors": [
            "1e6b46219a6638e42cabdbd9c2d9094c447ce46483f9dd202c958b8a525dbb93"
        ],
        "kinds": [
            4,
            1059
        ],
        "since": 1745275800
    }
]
```

Let's assume that new kind 4 event is created. Here is the code with commentaries which checks if event matches filters:

```python
# websocket_classes.py line 169
 for list_item in self.filters:
            for filter_, value in list_item.items():
                self.logger.debug(f"Checking filter: {filter_}, value : {value}")
                combined = {filter_: value}
                if self._match_single_filter(combined, event):
                    self.logger.debug(f"Event matches filter: {filter_}") # If event matches filter we simply go on to the next filter
                else:
                    self.logger.debug("filter did not match the event.")
                    return False # If event does not match filter we return False and do not care if there are more filters in a request
                                         # This was the problem in my case. The first filter does not match kind 4 event and client never receives it
            self.logger.debug("Returning true")
            return True
```

To solve this I simply swapped conditions. If **any** filter matches event then return `True`. If **no** filters match events then return `False`